### PR TITLE
Change ruby version to 2.2 in rubocop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -10,7 +10,7 @@ AllCops:
     - '**/Gemfile'
     - '**/Rakefile'
     - '**/Guardfile'
-  TargetRubyVersion: 2.2.2
+  TargetRubyVersion: 2.2
 Documentation:
   Enabled: false
 Metrics/AbcSize:


### PR DESCRIPTION
- Change rubocop ruby target version to ruby 2.2