### PR TITLE
Customer Import

### DIFF
--- a/app/models/shopify_import/customer.rb
+++ b/app/models/shopify_import/customer.rb
@@ -1,0 +1,4 @@
+module ShopifyImport
+  class Customer < ShopifyImport::Base
+  end
+end

--- a/app/services/shopify_import/creators/customer.rb
+++ b/app/services/shopify_import/creators/customer.rb
@@ -1,0 +1,50 @@
+module ShopifyImport
+  module Creators
+    class Customer
+      def initialize(shopify_data_feed)
+        @shopify_data_feed = shopify_data_feed
+      end
+
+      def save!
+        Spree.user_class.transaction do
+          @spree_user = create_spree_user
+          generate_api_key
+          assign_spree_user_to_data_feed
+        end
+      end
+
+      private
+
+      def create_spree_user
+        temp_password = SecureRandom.hex(64)
+        existing_attributes = user_attributes.select { |a| Spree.user_class.attribute_method?(a) }
+        user = Spree.user_class.new(
+          existing_attributes.merge(password: temp_password, password_confirmation: temp_password)
+        )
+        user.try(:skip_confirmation!)
+        user.save!
+        user
+      end
+
+      def assign_spree_user_to_data_feed
+        @shopify_data_feed.update!(spree_object: @spree_user)
+      end
+
+      def generate_api_key
+        @spree_user.try(:generate_spree_api_key!)
+      end
+
+      def user_attributes
+        parser.user_attributes
+      end
+
+      def parser
+        @parser ||= ShopifyImport::DataParsers::Customers::BaseData.new(shopify_customer)
+      end
+
+      def shopify_customer
+        @shopify_customer ||= ShopifyAPI::Customer.new(JSON.parse(@shopify_data_feed.data_feed))
+      end
+    end
+  end
+end

--- a/app/services/shopify_import/data_parsers/customers/base_data.rb
+++ b/app/services/shopify_import/data_parsers/customers/base_data.rb
@@ -1,0 +1,20 @@
+module ShopifyImport
+  module DataParsers
+    module Customers
+      class BaseData
+        def initialize(shopify_customer)
+          @shopify_customer = shopify_customer
+        end
+
+        def user_attributes
+          {
+            created_at: @shopify_customer.created_at,
+            email: @shopify_customer.email,
+            first_name: @shopify_customer.first_name,
+            last_name: @shopify_customer.last_name
+          }
+        end
+      end
+    end
+  end
+end

--- a/app/services/shopify_import/importers/customers_importer.rb
+++ b/app/services/shopify_import/importers/customers_importer.rb
@@ -1,0 +1,15 @@
+module ShopifyImport
+  module Importers
+    class CustomersImporter < BaseImporter
+      private
+
+      def resources
+        ShopifyImport::Customer.new(credentials: @credentials).find_all(@params)
+      end
+
+      def creator
+        ShopifyImport::Creators::Customer
+      end
+    end
+  end
+end

--- a/spec/factories/shopify_api/customer_factory.rb
+++ b/spec/factories/shopify_api/customer_factory.rb
@@ -1,0 +1,11 @@
+FactoryGirl.define do
+  factory :shopify_customer, class: ShopifyAPI::Customer do
+    skip_create
+    sequence(:id) { |n| n }
+    email FFaker::Internet.email
+    first_name FFaker::Name.first_name
+    last_name FFaker::Name.last_name
+    created_at '2011-10-20T14:05:13-04:00'
+    updated_at '2011-10-20T14:05:13-04:00'
+  end
+end

--- a/spec/models/shopify_import/customer_spec.rb
+++ b/spec/models/shopify_import/customer_spec.rb
@@ -1,0 +1,25 @@
+require 'spec_helper'
+
+RSpec.describe ShopifyImport::Customer, type: :module do
+  subject { described_class.new }
+
+  before do
+    Spree::Config[:shopify_api_key] = 'api_key'
+    Spree::Config[:shopify_password] = 'password'
+    Spree::Config[:shopify_shop_domain] = 'shop_domain.myshopify.com'
+  end
+
+  describe '#count', vcr: { cassette_name: 'shopify/customer/count' } do
+    let(:result) { { 'count' => 1 } }
+
+    it 'returns number of customers in shopify base' do
+      expect(subject.count).to eq result
+    end
+  end
+
+  describe '#find_all', vcr: { cassette_name: 'shopify/customer/find_all' } do
+    it 'find all customers in shopify' do
+      expect(subject.find_all.length).to eq 1
+    end
+  end
+end

--- a/spec/services/shopify_import/creators/customer_spec.rb
+++ b/spec/services/shopify_import/creators/customer_spec.rb
@@ -1,0 +1,80 @@
+require 'spec_helper'
+
+RSpec.describe ShopifyImport::Creators::Customer do
+  subject { described_class.new(customer_data_feed) }
+
+  before { ShopifyAPI::Base.site = 'https://foo:baz@test_shop.myshopify.com/admin' }
+
+  describe '#save!' do
+    context 'with base customer data feed' do
+      let(:shopify_customer) do
+        ShopifyAPI::Customer.new(
+          created_at: 2.days.ago, email: 'user@example.com',
+          first_name: 'User', last_name: 'Example'
+        )
+      end
+      let(:customer_data_feed) { create(:shopify_data_feed, data_feed: shopify_customer.to_json) }
+
+      it 'create spree user' do
+        expect { subject.save! }.to change(Spree.user_class, :count).by(1)
+      end
+
+      it 'skips sending confirmation email' do
+        user = Spree.user_class.new
+        allow(Spree.user_class).to receive(:new) do |method_attributes|
+          user.assign_attributes(method_attributes)
+          user
+        end
+        allow(user).to receive(:skip_confirmation!)
+
+        subject.save!
+
+        expect(user).to have_received(:skip_confirmation!)
+      end
+
+      it 'generates spree api key' do
+        subject.save!
+        spree_user = Spree.user_class.find_by!(email: shopify_customer.email)
+
+        expect(spree_user.spree_api_key).not_to be_blank
+      end
+
+      it 'assigns shopify data feed to spree user' do
+        subject.save!
+        expect(customer_data_feed.reload.spree_object).to eq(Spree.user_class.find_by!(email: shopify_customer.email))
+      end
+
+      context 'customer attributes' do
+        let(:spree_user) { Spree.user_class.find_by!(email: shopify_customer.email) }
+
+        it 'assigns temp password to the user' do
+          password = 'hex_password'
+          allow(SecureRandom).to receive(:hex).and_call_original
+          allow(SecureRandom).to receive(:hex).with(64).and_return(password)
+
+          subject.save!
+
+          expect(spree_user.valid_password?(password)).to be true
+        end
+
+        it 'email' do
+          subject.save!
+
+          expect(spree_user.email).to eq(shopify_customer.email)
+        end
+
+        it 'assigns login from email' do
+          subject.save!
+
+          expect(spree_user.login).to eq(shopify_customer.email)
+        end
+
+        it 'created_at' do
+          subject.save!
+
+          expect(spree_user.created_at).to be_within(1.second).of(shopify_customer.created_at)
+        end
+      end
+    end
+  end
+end

--- a/spec/services/shopify_import/data_parsers/customers/base_data_spec.rb
+++ b/spec/services/shopify_import/data_parsers/customers/base_data_spec.rb
@@ -1,0 +1,23 @@
+require 'spec_helper'
+
+RSpec.describe ShopifyImport::DataParsers::Customers::BaseData do
+  subject { described_class.new(shopify_customer) }
+  let(:shopify_customer) { create(:shopify_customer) }
+
+  describe '#user_attributes' do
+    context 'with sample customer' do
+      let(:user_attributes) do
+        {
+          created_at: shopify_customer.created_at,
+          email: shopify_customer.email,
+          first_name: shopify_customer.first_name,
+          last_name: shopify_customer.last_name
+        }
+      end
+
+      it 'prepares hash of attributes' do
+        expect(subject.user_attributes).to eq(user_attributes)
+      end
+    end
+  end
+end

--- a/spec/services/shopify_import/importers/customers_importer_spec.rb
+++ b/spec/services/shopify_import/importers/customers_importer_spec.rb
@@ -1,0 +1,19 @@
+require 'spec_helper'
+
+RSpec.describe ShopifyImport::Importers::CustomersImporter do
+  describe '.import!', vcr: { cassette_name: 'shopify_import/importers/customers_importer/import' } do
+    before do
+      Spree::Config[:shopify_api_key] = 'api_key'
+      Spree::Config[:shopify_password] = 'password'
+      Spree::Config[:shopify_shop_domain] = 'shop_domain.myshopify.com'
+    end
+
+    it 'creates shopify data feeds' do
+      expect { described_class.import! }.to change(Shopify::DataFeed, :count).by(1)
+    end
+
+    it 'creates spree users' do
+      expect { described_class.import! }.to change(Spree.user_class, :count).by(1)
+    end
+  end
+end

--- a/spec/vcr/shopify/customer/count.yml
+++ b/spec/vcr/shopify/customer/count.yml
@@ -1,0 +1,100 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://shop_domain.myshopify.com/admin/customers/count.json
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Basic MGE5NDQ1YjdiMDY3NzE5YTBhZjAyNDYxMDM2NGVlMzQ6ODAwZjk3ZDZlYTFhNzY4MDQ4ODUxY2RkOTlhOTEwMWE=
+      Accept:
+      - application/json
+      User-Agent:
+      - ShopifyAPI/4.9.0 ActiveResource/5.0.0 Ruby/2.4.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Fri, 02 Jun 2017 04:57:48 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Sorting-Hat-Podid:
+      - '3'
+      - '3'
+      X-Sorting-Hat-Podid-Cached:
+      - '1'
+      - '1'
+      X-Sorting-Hat-Shopid:
+      - '20513691'
+      - '20513691'
+      X-Sorting-Hat-Section:
+      - pod
+      - pod
+      X-Sorting-Hat-Shopid-Cached:
+      - '0'
+      - '0'
+      Vary:
+      - Accept-Encoding
+      Referrer-Policy:
+      - origin-when-cross-origin
+      X-Frame-Options:
+      - DENY
+      X-Shopid:
+      - '20513691'
+      X-Shardid:
+      - '3'
+      X-Shopify-Shop-Api-Call-Limit:
+      - 1/40
+      Http-X-Shopify-Shop-Api-Call-Limit:
+      - 1/40
+      X-Stats-Userid:
+      - '0'
+      X-Stats-Apiclientid:
+      - '1680429'
+      X-Stats-Apipermissionid:
+      - '52824317'
+      Content-Security-Policy:
+      - 'default-src ''self'' data: blob: ''unsafe-inline'' ''unsafe-eval'' https://*
+        shopify-pos://*; block-all-mixed-content; child-src ''self'' https://* shopify-pos://*;
+        connect-src ''self'' wss://* https://*; script-src https://cdn.shopify.com
+        https://checkout.shopifycs.com https://js-agent.newrelic.com https://bam.nr-data.net
+        https://dme0ih8comzn4.cloudfront.net https://api.stripe.com https://mpsnare.iesnare.com
+        https://appcenter.intuit.com https://www.paypal.com https://maps.googleapis.com
+        https://stats.g.doubleclick.net https://www.google-analytics.com https://visitors.shopify.com
+        https://v.shopify.com https://widget.intercom.io https://js.intercomcdn.com
+        ''self'' ''unsafe-inline'' ''unsafe-eval''; upgrade-insecure-requests; report-uri
+        /csp-report?source%5Baction%5D=count&source%5Bapp%5D=Shopify&source%5Bcontroller%5D=admin%2Fcustomers&source%5Bsection%5D=admin&source%5Buuid%5D=f86c2f26-26ee-438f-9200-1a31f589cd26'
+      X-Content-Type-Options:
+      - nosniff
+      - nosniff
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Xss-Protection:
+      - 1; mode=block; report=/xss-report?source%5Baction%5D=count&source%5Bapp%5D=Shopify&source%5Bcontroller%5D=admin%2Fcustomers&source%5Bsection%5D=admin&source%5Buuid%5D=f86c2f26-26ee-438f-9200-1a31f589cd26
+      P3p:
+      - CP="NOI DSP COR NID ADMa OPTa OUR NOR"
+      X-Dc:
+      - chi2,ash
+      X-Request-Id:
+      - f86c2f26-26ee-438f-9200-1a31f589cd26
+    body:
+      encoding: ASCII-8BIT
+      string: '{"count":1}'
+    http_version:
+  recorded_at: Fri, 02 Jun 2017 04:57:48 GMT
+recorded_with: VCR 3.0.3

--- a/spec/vcr/shopify/customer/find_all.yml
+++ b/spec/vcr/shopify/customer/find_all.yml
@@ -1,0 +1,201 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://shop_domain.myshopify.com/admin/customers.json?page=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Basic MGE5NDQ1YjdiMDY3NzE5YTBhZjAyNDYxMDM2NGVlMzQ6ODAwZjk3ZDZlYTFhNzY4MDQ4ODUxY2RkOTlhOTEwMWE=
+      Accept:
+      - application/json
+      User-Agent:
+      - ShopifyAPI/4.9.0 ActiveResource/5.0.0 Ruby/2.4.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Fri, 02 Jun 2017 04:57:49 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Sorting-Hat-Podid:
+      - '3'
+      - '3'
+      X-Sorting-Hat-Podid-Cached:
+      - '1'
+      - '1'
+      X-Sorting-Hat-Shopid:
+      - '20513691'
+      - '20513691'
+      X-Sorting-Hat-Section:
+      - pod
+      - pod
+      X-Sorting-Hat-Shopid-Cached:
+      - '1'
+      - '1'
+      Vary:
+      - Accept-Encoding
+      Referrer-Policy:
+      - origin-when-cross-origin
+      X-Frame-Options:
+      - DENY
+      X-Shopid:
+      - '20513691'
+      X-Shardid:
+      - '3'
+      X-Shopify-Shop-Api-Call-Limit:
+      - 1/40
+      Http-X-Shopify-Shop-Api-Call-Limit:
+      - 1/40
+      X-Stats-Userid:
+      - '0'
+      X-Stats-Apiclientid:
+      - '1680429'
+      X-Stats-Apipermissionid:
+      - '52824317'
+      Content-Security-Policy:
+      - 'default-src ''self'' data: blob: ''unsafe-inline'' ''unsafe-eval'' https://*
+        shopify-pos://*; block-all-mixed-content; child-src ''self'' https://* shopify-pos://*;
+        connect-src ''self'' wss://* https://*; script-src https://cdn.shopify.com
+        https://checkout.shopifycs.com https://js-agent.newrelic.com https://bam.nr-data.net
+        https://dme0ih8comzn4.cloudfront.net https://api.stripe.com https://mpsnare.iesnare.com
+        https://appcenter.intuit.com https://www.paypal.com https://maps.googleapis.com
+        https://stats.g.doubleclick.net https://www.google-analytics.com https://visitors.shopify.com
+        https://v.shopify.com https://widget.intercom.io https://js.intercomcdn.com
+        ''self'' ''unsafe-inline'' ''unsafe-eval''; upgrade-insecure-requests; report-uri
+        /csp-report?source%5Baction%5D=index&source%5Bapp%5D=Shopify&source%5Bcontroller%5D=admin%2Fcustomers&source%5Bsection%5D=admin&source%5Buuid%5D=15e5292b-3bdf-4125-87a7-252f6573064a'
+      X-Content-Type-Options:
+      - nosniff
+      - nosniff
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Xss-Protection:
+      - 1; mode=block; report=/xss-report?source%5Baction%5D=index&source%5Bapp%5D=Shopify&source%5Bcontroller%5D=admin%2Fcustomers&source%5Bsection%5D=admin&source%5Buuid%5D=15e5292b-3bdf-4125-87a7-252f6573064a
+      P3p:
+      - CP="NOI DSP COR NID ADMa OPTa OUR NOR"
+      X-Dc:
+      - chi2,ash
+      X-Request-Id:
+      - 15e5292b-3bdf-4125-87a7-252f6573064a
+    body:
+      encoding: ASCII-8BIT
+      string: '{"customers":[{"id":5657503684,"email":"viktor.fonic@gmail.com","accepts_marketing":false,"created_at":"2017-06-02T00:56:49-04:00","updated_at":"2017-06-02T00:56:49-04:00","first_name":"Viktor","last_name":"Fonic","orders_count":0,"state":"disabled","total_spent":"0.00","last_order_id":null,"note":"","verified_email":true,"multipass_identifier":null,"tax_exempt":false,"phone":null,"tags":"","last_order_name":null,"addresses":[{"id":5931674052,"first_name":"Viktor","last_name":"Fonic","company":"Smart
+        Development Ltd.","address1":"Ideo Mobi East Gate","address2":"Sukhumvit 46","city":"Bangkok","province":"","country":"Thailand","zip":"10110","phone":"","name":"Viktor
+        Fonic","province_code":null,"country_code":"TH","country_name":"Thailand","default":true}],"default_address":{"id":5931674052,"first_name":"Viktor","last_name":"Fonic","company":"Smart
+        Development Ltd.","address1":"Ideo Mobi East Gate","address2":"Sukhumvit 46","city":"Bangkok","province":"","country":"Thailand","zip":"10110","phone":"","name":"Viktor
+        Fonic","province_code":null,"country_code":"TH","country_name":"Thailand","default":true}}]}'
+    http_version:
+  recorded_at: Fri, 02 Jun 2017 04:57:49 GMT
+- request:
+    method: get
+    uri: https://shop_domain.myshopify.com/admin/customers.json?page=2
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Basic MGE5NDQ1YjdiMDY3NzE5YTBhZjAyNDYxMDM2NGVlMzQ6ODAwZjk3ZDZlYTFhNzY4MDQ4ODUxY2RkOTlhOTEwMWE=
+      Accept:
+      - application/json
+      User-Agent:
+      - ShopifyAPI/4.9.0 ActiveResource/5.0.0 Ruby/2.4.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Fri, 02 Jun 2017 04:57:50 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Sorting-Hat-Podid:
+      - '3'
+      - '3'
+      X-Sorting-Hat-Podid-Cached:
+      - '1'
+      - '1'
+      X-Sorting-Hat-Shopid:
+      - '20513691'
+      - '20513691'
+      X-Sorting-Hat-Section:
+      - pod
+      - pod
+      X-Sorting-Hat-Shopid-Cached:
+      - '1'
+      - '1'
+      Vary:
+      - Accept-Encoding
+      Referrer-Policy:
+      - origin-when-cross-origin
+      X-Frame-Options:
+      - DENY
+      X-Shopid:
+      - '20513691'
+      X-Shardid:
+      - '3'
+      X-Shopify-Shop-Api-Call-Limit:
+      - 1/40
+      Http-X-Shopify-Shop-Api-Call-Limit:
+      - 1/40
+      X-Stats-Userid:
+      - '0'
+      X-Stats-Apiclientid:
+      - '1680429'
+      X-Stats-Apipermissionid:
+      - '52824317'
+      Content-Security-Policy:
+      - 'default-src ''self'' data: blob: ''unsafe-inline'' ''unsafe-eval'' https://*
+        shopify-pos://*; block-all-mixed-content; child-src ''self'' https://* shopify-pos://*;
+        connect-src ''self'' wss://* https://*; script-src https://cdn.shopify.com
+        https://checkout.shopifycs.com https://js-agent.newrelic.com https://bam.nr-data.net
+        https://dme0ih8comzn4.cloudfront.net https://api.stripe.com https://mpsnare.iesnare.com
+        https://appcenter.intuit.com https://www.paypal.com https://maps.googleapis.com
+        https://stats.g.doubleclick.net https://www.google-analytics.com https://visitors.shopify.com
+        https://v.shopify.com https://widget.intercom.io https://js.intercomcdn.com
+        ''self'' ''unsafe-inline'' ''unsafe-eval''; upgrade-insecure-requests; report-uri
+        /csp-report?source%5Baction%5D=index&source%5Bapp%5D=Shopify&source%5Bcontroller%5D=admin%2Fcustomers&source%5Bsection%5D=admin&source%5Buuid%5D=a7dd850c-163f-450a-9c99-499b4f44d355'
+      X-Content-Type-Options:
+      - nosniff
+      - nosniff
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Xss-Protection:
+      - 1; mode=block; report=/xss-report?source%5Baction%5D=index&source%5Bapp%5D=Shopify&source%5Bcontroller%5D=admin%2Fcustomers&source%5Bsection%5D=admin&source%5Buuid%5D=a7dd850c-163f-450a-9c99-499b4f44d355
+      P3p:
+      - CP="NOI DSP COR NID ADMa OPTa OUR NOR"
+      X-Dc:
+      - chi2,ash
+      X-Request-Id:
+      - a7dd850c-163f-450a-9c99-499b4f44d355
+    body:
+      encoding: ASCII-8BIT
+      string: '{"customers":[]}'
+    http_version:
+  recorded_at: Fri, 02 Jun 2017 04:57:50 GMT
+recorded_with: VCR 3.0.3

--- a/spec/vcr/shopify_import/importers/customers_importer/import.yml
+++ b/spec/vcr/shopify_import/importers/customers_importer/import.yml
@@ -1,0 +1,201 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://shop_domain.myshopify.com/admin/customers.json?page=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Basic MGE5NDQ1YjdiMDY3NzE5YTBhZjAyNDYxMDM2NGVlMzQ6ODAwZjk3ZDZlYTFhNzY4MDQ4ODUxY2RkOTlhOTEwMWE=
+      Accept:
+      - application/json
+      User-Agent:
+      - ShopifyAPI/4.9.0 ActiveResource/5.0.0 Ruby/2.4.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Fri, 02 Jun 2017 06:25:01 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Sorting-Hat-Podid:
+      - '3'
+      - '3'
+      X-Sorting-Hat-Podid-Cached:
+      - '0'
+      - '0'
+      X-Sorting-Hat-Shopid:
+      - '20513691'
+      - '20513691'
+      X-Sorting-Hat-Section:
+      - pod
+      - pod
+      X-Sorting-Hat-Shopid-Cached:
+      - '0'
+      - '0'
+      Vary:
+      - Accept-Encoding
+      Referrer-Policy:
+      - origin-when-cross-origin
+      X-Frame-Options:
+      - DENY
+      X-Shopid:
+      - '20513691'
+      X-Shardid:
+      - '3'
+      X-Shopify-Shop-Api-Call-Limit:
+      - 1/40
+      Http-X-Shopify-Shop-Api-Call-Limit:
+      - 1/40
+      X-Stats-Userid:
+      - '0'
+      X-Stats-Apiclientid:
+      - '1680429'
+      X-Stats-Apipermissionid:
+      - '52824317'
+      Content-Security-Policy:
+      - 'default-src ''self'' data: blob: ''unsafe-inline'' ''unsafe-eval'' https://*
+        shopify-pos://*; block-all-mixed-content; child-src ''self'' https://* shopify-pos://*;
+        connect-src ''self'' wss://* https://*; script-src https://cdn.shopify.com
+        https://checkout.shopifycs.com https://js-agent.newrelic.com https://bam.nr-data.net
+        https://dme0ih8comzn4.cloudfront.net https://api.stripe.com https://mpsnare.iesnare.com
+        https://appcenter.intuit.com https://www.paypal.com https://maps.googleapis.com
+        https://stats.g.doubleclick.net https://www.google-analytics.com https://visitors.shopify.com
+        https://v.shopify.com https://widget.intercom.io https://js.intercomcdn.com
+        ''self'' ''unsafe-inline'' ''unsafe-eval''; upgrade-insecure-requests; report-uri
+        /csp-report?source%5Baction%5D=index&source%5Bapp%5D=Shopify&source%5Bcontroller%5D=admin%2Fcustomers&source%5Bsection%5D=admin&source%5Buuid%5D=b2b0fa4b-46ca-453c-838c-f8a1f8ca9cc6'
+      X-Content-Type-Options:
+      - nosniff
+      - nosniff
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Xss-Protection:
+      - 1; mode=block; report=/xss-report?source%5Baction%5D=index&source%5Bapp%5D=Shopify&source%5Bcontroller%5D=admin%2Fcustomers&source%5Bsection%5D=admin&source%5Buuid%5D=b2b0fa4b-46ca-453c-838c-f8a1f8ca9cc6
+      P3p:
+      - CP="NOI DSP COR NID ADMa OPTa OUR NOR"
+      X-Dc:
+      - chi2,ash
+      X-Request-Id:
+      - b2b0fa4b-46ca-453c-838c-f8a1f8ca9cc6
+    body:
+      encoding: ASCII-8BIT
+      string: '{"customers":[{"id":5657503684,"email":"viktor.fonic@gmail.com","accepts_marketing":false,"created_at":"2017-06-02T00:56:49-04:00","updated_at":"2017-06-02T00:56:49-04:00","first_name":"Viktor","last_name":"Fonic","orders_count":0,"state":"disabled","total_spent":"0.00","last_order_id":null,"note":"","verified_email":true,"multipass_identifier":null,"tax_exempt":false,"phone":null,"tags":"","last_order_name":null,"addresses":[{"id":5931674052,"first_name":"Viktor","last_name":"Fonic","company":"Smart
+        Development Ltd.","address1":"Ideo Mobi East Gate","address2":"Sukhumvit 46","city":"Bangkok","province":"","country":"Thailand","zip":"10110","phone":"","name":"Viktor
+        Fonic","province_code":null,"country_code":"TH","country_name":"Thailand","default":true}],"default_address":{"id":5931674052,"first_name":"Viktor","last_name":"Fonic","company":"Smart
+        Development Ltd.","address1":"Ideo Mobi East Gate","address2":"Sukhumvit 46","city":"Bangkok","province":"","country":"Thailand","zip":"10110","phone":"","name":"Viktor
+        Fonic","province_code":null,"country_code":"TH","country_name":"Thailand","default":true}}]}'
+    http_version:
+  recorded_at: Fri, 02 Jun 2017 06:25:01 GMT
+- request:
+    method: get
+    uri: https://shop_domain.myshopify.com/admin/customers.json?page=2
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Basic MGE5NDQ1YjdiMDY3NzE5YTBhZjAyNDYxMDM2NGVlMzQ6ODAwZjk3ZDZlYTFhNzY4MDQ4ODUxY2RkOTlhOTEwMWE=
+      Accept:
+      - application/json
+      User-Agent:
+      - ShopifyAPI/4.9.0 ActiveResource/5.0.0 Ruby/2.4.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Fri, 02 Jun 2017 06:25:02 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Sorting-Hat-Podid:
+      - '3'
+      - '3'
+      X-Sorting-Hat-Podid-Cached:
+      - '0'
+      - '0'
+      X-Sorting-Hat-Shopid:
+      - '20513691'
+      - '20513691'
+      X-Sorting-Hat-Section:
+      - pod
+      - pod
+      X-Sorting-Hat-Shopid-Cached:
+      - '0'
+      - '0'
+      Vary:
+      - Accept-Encoding
+      Referrer-Policy:
+      - origin-when-cross-origin
+      X-Frame-Options:
+      - DENY
+      X-Shopid:
+      - '20513691'
+      X-Shardid:
+      - '3'
+      X-Shopify-Shop-Api-Call-Limit:
+      - 1/40
+      Http-X-Shopify-Shop-Api-Call-Limit:
+      - 1/40
+      X-Stats-Userid:
+      - '0'
+      X-Stats-Apiclientid:
+      - '1680429'
+      X-Stats-Apipermissionid:
+      - '52824317'
+      Content-Security-Policy:
+      - 'default-src ''self'' data: blob: ''unsafe-inline'' ''unsafe-eval'' https://*
+        shopify-pos://*; block-all-mixed-content; child-src ''self'' https://* shopify-pos://*;
+        connect-src ''self'' wss://* https://*; script-src https://cdn.shopify.com
+        https://checkout.shopifycs.com https://js-agent.newrelic.com https://bam.nr-data.net
+        https://dme0ih8comzn4.cloudfront.net https://api.stripe.com https://mpsnare.iesnare.com
+        https://appcenter.intuit.com https://www.paypal.com https://maps.googleapis.com
+        https://stats.g.doubleclick.net https://www.google-analytics.com https://visitors.shopify.com
+        https://v.shopify.com https://widget.intercom.io https://js.intercomcdn.com
+        ''self'' ''unsafe-inline'' ''unsafe-eval''; upgrade-insecure-requests; report-uri
+        /csp-report?source%5Baction%5D=index&source%5Bapp%5D=Shopify&source%5Bcontroller%5D=admin%2Fcustomers&source%5Bsection%5D=admin&source%5Buuid%5D=4753f218-770f-4e75-96b3-bd8d1d7e625b'
+      X-Content-Type-Options:
+      - nosniff
+      - nosniff
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Xss-Protection:
+      - 1; mode=block; report=/xss-report?source%5Baction%5D=index&source%5Bapp%5D=Shopify&source%5Bcontroller%5D=admin%2Fcustomers&source%5Bsection%5D=admin&source%5Buuid%5D=4753f218-770f-4e75-96b3-bd8d1d7e625b
+      P3p:
+      - CP="NOI DSP COR NID ADMa OPTa OUR NOR"
+      X-Dc:
+      - chi2,ash
+      X-Request-Id:
+      - 4753f218-770f-4e75-96b3-bd8d1d7e625b
+    body:
+      encoding: ASCII-8BIT
+      string: '{"customers":[]}'
+    http_version:
+  recorded_at: Fri, 02 Jun 2017 06:25:03 GMT
+recorded_with: VCR 3.0.3


### PR DESCRIPTION
Couple of things to note:

* Import assigns temporary password to customer. We should provide a way for store admins to send email to all users
  with a reset password link or similar functionality, since users won't be able to login because they don't know the
  temporary password.
* The import process calls `skip_confirmation!` in order to prevent devise from sending a confirmation email to imported
  users
* Optionally: If spree user model has `first_name` and `last_name` columns, those will be imported as well
* During the import, I also generate `spree_api_key` (if available)
* I opted not to use vcr for customer creator specs. I use vcr only for CustomersImporter