### PR TITLE
Feature/order import 1

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -40,6 +40,8 @@ Lint/EndAlignment:
   AutoCorrect: true
 Rails:
   Enabled: true
+Rails/SkipsModelValidations:
+  Enabled: false
 Rails/Output:
   Enabled: false
 Style/FrozenStringLiteralComment:

--- a/app/models/shopify_import/order.rb
+++ b/app/models/shopify_import/order.rb
@@ -1,0 +1,4 @@
+module ShopifyImport
+  class Order < Base
+  end
+end

--- a/app/services/shopify_import/creators/order.rb
+++ b/app/services/shopify_import/creators/order.rb
@@ -1,0 +1,46 @@
+module ShopifyImport
+  module Creators
+    class Order < ShopifyImport::Creators::Base
+      def save!
+        Spree::Order.transaction do
+          @spree_order = create_spree_order
+          assign_spree_order_to_data_feed
+          @spree_order.update_columns(order_timestamps)
+        end
+      end
+
+      private
+
+      def create_spree_order
+        order = Spree::Order.new(user: user)
+        order.assign_attributes(order_attributes)
+        order.save!
+        order
+      end
+
+      def user
+        parser.user
+      end
+
+      def order_attributes
+        parser.order_attributes.select { |a| Spree::Order.attribute_method?(a) }
+      end
+
+      def order_timestamps
+        parser.order_timestamps
+      end
+
+      def parser
+        @parser ||= ShopifyImport::DataParsers::Orders::BaseData.new(shopify_order)
+      end
+
+      def shopify_order
+        @shopify_order ||= ShopifyAPI::Order.new(data_feed)
+      end
+
+      def assign_spree_order_to_data_feed
+        @shopify_data_feed.update!(spree_object: @spree_order)
+      end
+    end
+  end
+end

--- a/app/services/shopify_import/data_parsers/orders/base_data.rb
+++ b/app/services/shopify_import/data_parsers/orders/base_data.rb
@@ -1,0 +1,113 @@
+module ShopifyImport
+  module DataParsers
+    module Orders
+      class BaseData
+        def initialize(shopify_order)
+          @shopify_order = shopify_order
+        end
+
+        # TODO: USER NOT CREATED
+        def user
+          return if (customer = @shopify_order.customer).blank?
+
+          @user ||= Shopify::DataFeed.find_by(shopify_object_id: customer.id,
+                                              shopify_object_type: 'ShopifyAPI::Customer').try(:spree_object)
+        end
+
+        def order_attributes
+          [base_order_attributes, order_totals, order_states].inject(&:merge)
+        end
+
+        def order_timestamps
+          {
+            created_at: @shopify_order.created_at.to_datetime,
+            updated_at: @shopify_order.updated_at.to_datetime
+          }
+        end
+
+        private
+
+        # TODO: COMPLETED AT
+        def base_order_attributes
+          {
+            number: @shopify_order.order_number,
+            email: @shopify_order.email,
+            channel: I18n.t('shopify'),
+            currency: @shopify_order.currency,
+            note: @shopify_order.note,
+            confirmation_delivered: @shopify_order.confirmed,
+            last_ip_address: @shopify_order.browser_ip,
+            item_count: @shopify_order.line_items.sum(&:quantity)
+          }
+        end
+
+        # TODO: ORDER ADJUSTMENT TOTAL
+        # TODO: ORDER INCLUDED TAX TOTAL
+        def order_totals
+          {
+            total: @shopify_order.total_price,
+            item_total: @shopify_order.total_line_items_price,
+            additional_tax_total: @shopify_order.total_tax,
+            promo_total: - @shopify_order.total_discounts.to_d,
+            payment_total: payment_total,
+            shipment_total: shipment_total
+          }
+        end
+
+        def order_states
+          {
+            state: order_state,
+            payment_state: payment_state,
+            shipment_state: shipment_state
+          }
+        end
+
+        def payment_total
+          transactions = @shopify_order.transactions.select do |t|
+            %w[sale capture].include?(t.kind)
+          end
+
+          transactions.select { |t| t.status == 'success' }.sum(&:amount)
+        end
+
+        def shipment_total
+          @shopify_order.shipping_lines.sum(&:price)
+        end
+
+        def order_state
+          return 'returned' if @shopify_order.financial_status.eql?('refunded')
+
+          case payment_state
+          when 'paid', 'balance_due' then 'complete'
+          when 'void' then 'canceled'
+          when 'pending' then shipment_state.eql?('shipped') ? 'complete' : 'pending'
+          else
+            raise NotImplementedError
+          end
+        end
+
+        def payment_state
+          @payment_state ||= case @shopify_order.financial_status
+                             when 'pending', 'partially_paid' then 'balance_due'
+                             when 'authorized', 'paid', 'partially_refunded', 'refunded' then 'paid'
+                             when 'voided' then 'void'
+                             else
+                               raise NotImplementedError
+                             end
+        end
+
+        def shipment_state
+          @shipment_state ||= case @shopify_order.fulfillment_status
+                              when 'fulfilled' then 'shipped'
+                              when 'unfulfilled' then 'ready'
+                              when 'restocked' then 'canceled'
+                              when nil, '' then nil
+                              when 'pending', 'partial' then 'pending'
+                              else
+                                raise NotImplementedError
+                              end
+        end
+      end
+    end
+  end
+end

--- a/lib/spree_shopify_importer/factories/shopify_api/order_factory.rb
+++ b/lib/spree_shopify_importer/factories/shopify_api/order_factory.rb
@@ -1,0 +1,62 @@
+FactoryGirl.define do
+  factory :shopify_order, class: ShopifyAPI::Order do
+    skip_create
+    sequence(:id) { |n| n }
+    email FFaker::Internet.email
+    closed_at nil
+    created_at Time.current
+    updated_at Time.current
+    number { rand(10_000..20_000) }
+    note FFaker::Lorem.sentence
+    token 'token'
+    gateway 'Bank Deposit'
+    test true
+    total_price { rand(100.00..200.00) }
+    subtotal_price { rand(100.00..200.00) }
+    total_weight 0
+    total_tax { rand(10.00..20.00) }
+    taxes_included true
+    currency 'USD'
+    financial_status 'paid'
+    confirmed true
+    total_discounts { rand(100.00..200.00) }
+    total_line_items_price { rand(100.00..200.00) }
+    cart_token 'cart_token'
+    buyer_accepts_marketing true
+    name '#1'
+    referring_site ''
+    landing_site '/'
+    cancelled_at nil
+    cancel_reason nil
+    total_price_usd { total_price }
+    checkout_token 'checkout_token'
+    reference nil
+    location_id nil
+    source_identifier nil
+    source_url nil
+    processed_at Time.current
+    device_id nil
+    browser_ip '127.0.0.1'
+    landing_site_ref nil
+    order_number '1'
+    note_attributes []
+    payment_gateway_names ['Bank Deposit']
+    processing_method 'manual'
+    checkout_id 6_974_564_679
+    source_name 'web'
+    fulfillment_status 'fulfilled'
+    tags ''
+    contact_email FFaker::Internet.email
+    order_status_url 'https://checkout.shopify.com/someidentifier/checkouts/uniquehash/thank_you_token?key=somekeyvalue'
+    refunds []
+    discount_codes []
+    customer { create(:shopify_customer) }
+    user_id { customer.id }
+    tax_lines []
+    shipping_lines { [create(:shopify_shipping_line)] }
+    billing_address []
+    shipping_address []
+    fulfillments []
+    line_items []
+  end
+end

--- a/lib/spree_shopify_importer/factories/shopify_api/shipping_line_factory.rb
+++ b/lib/spree_shopify_importer/factories/shopify_api/shipping_line_factory.rb
@@ -1,0 +1,14 @@
+FactoryGirl.define do
+  factory :shopify_shipping_line, class: ShopifyAPI::ShippingLine do
+    skip_create
+    sequence(:id) { |n| n }
+    title 'UPS'
+    code 'UPS'
+    price { rand(10.00..15.00) }
+    source 'shopify'
+    phone nil
+    carrier_identifier nil
+    tax_lines []
+    rate 0.22
+  end
+end

--- a/lib/spree_shopify_importer/factories/shopify_api/transaction_factory.rb
+++ b/lib/spree_shopify_importer/factories/shopify_api/transaction_factory.rb
@@ -1,0 +1,18 @@
+FactoryGirl.define do
+  factory :shopify_transaction, class: ShopifyAPI::Transaction do
+    skip_create
+    sequence(:id) { |n| n }
+    amount { rand(100.00..200.00) }
+    authorization nil
+    created_at Time.current
+    device_id nil
+    gateway 'Bank Deposit'
+    source_name 'web'
+    kind 'sale'
+    order { create(:shopify_order) }
+    receipt 'testcase'
+    status 'success'
+    currency 'USD'
+    user_id { order.customer.id }
+  end
+end

--- a/spec/models/shopify_import/order_spec.rb
+++ b/spec/models/shopify_import/order_spec.rb
@@ -1,0 +1,21 @@
+require 'spec_helper'
+
+RSpec.describe ShopifyImport::Order, type: :model do
+  subject { described_class }
+
+  before { authenticate_with_shopify }
+
+  describe '.count', vcr: { cassette_name: 'shopify/order/count' } do
+    let(:result) { { 'count' => 1 } }
+
+    it 'returns number of customers in Shopify' do
+      expect(subject.count).to eq result
+    end
+  end
+
+  describe '.all', vcr: { cassette_name: 'shopify/order/all' } do
+    it 'find all customers in Shopify' do
+      expect(subject.all.length).to eq 1
+    end
+  end
+end

--- a/spec/services/shopify_import/creators/order_spec.rb
+++ b/spec/services/shopify_import/creators/order_spec.rb
@@ -1,0 +1,130 @@
+require 'spec_helper'
+
+RSpec.describe ShopifyImport::Creators::Order, type: :service do
+  subject { described_class.new(order_data_feed) }
+
+  before { authenticate_with_shopify }
+
+  describe '#save!' do
+    context 'with base shopify order data', vcr: { cassette_name: 'shopify/base_order' } do
+      let(:shopify_order) { ShopifyAPI::Order.find(5_182_437_124) }
+      let(:order_data_feed) do
+        create(:shopify_data_feed,
+               shopify_object_id: shopify_order.id, data_feed: shopify_order.to_json)
+      end
+      let(:spree_order) { Spree::Order.find_by!(number: shopify_order.order_number) }
+
+      it 'creates spree order' do
+        expect { subject.save! }.to change(Spree::Order, :count).by(1)
+      end
+
+      it 'assigns shopify data feed to spree order' do
+        subject.save!
+        expect(order_data_feed.reload.spree_object).to eq spree_order
+      end
+
+      context 'with existing user' do
+        let(:user) { create(:user) }
+        let!(:user_data_feed) do
+          create(:shopify_data_feed,
+                 spree_object: user,
+                 shopify_object_id: shopify_order.customer.id,
+                 shopify_object_type: 'ShopifyAPI::Customer')
+        end
+
+        it 'assigns order to user' do
+          subject.save!
+          expect(spree_order.reload.user).to eq user
+        end
+      end
+
+      context 'sets order attributes' do
+        before { subject.save! }
+
+        it 'number' do
+          expect(spree_order.number).to eq '1001'
+        end
+
+        it 'email' do
+          expect(spree_order.email).to eq 'example@example.com'
+        end
+
+        it 'channel' do
+          expect(spree_order.channel).to eq I18n.t(:shopify)
+        end
+
+        it 'currency' do
+          expect(spree_order.currency).to eq 'EUR'
+        end
+
+        it 'confirmation_delivered' do
+          expect(spree_order.confirmation_delivered).to be_truthy
+        end
+
+        it 'last_ip_address' do
+          expect(spree_order.last_ip_address).to be_nil
+        end
+
+        it 'item_count' do
+          expect(spree_order.item_count).to eq 8
+        end
+      end
+
+      context 'sets order totals' do
+        before { subject.save! }
+
+        it 'total' do
+          expect(spree_order.total).to eq 470.0.to_d
+        end
+
+        it 'item total' do
+          expect(spree_order.item_total).to eq 450.0.to_d
+        end
+
+        it 'additional tax total' do
+          expect(spree_order.additional_tax_total).to eq 0
+        end
+
+        it 'promo total' do
+          expect(spree_order.promo_total).to eq 0
+        end
+
+        it 'payment total' do
+          expect(spree_order.payment_total).to eq 470.0.to_d
+        end
+
+        it 'shipment total' do
+          expect(spree_order.shipment_total).to eq 20.0.to_d
+        end
+      end
+
+      context 'sets order states' do
+        before { subject.save! }
+
+        it 'state' do
+          expect(spree_order.state).to eq 'complete'
+        end
+
+        it 'payment state' do
+          expect(spree_order.payment_state).to eq 'paid'
+        end
+
+        it 'shipment state' do
+          expect(spree_order.shipment_state).to eq 'pending'
+        end
+      end
+
+      context 'sets order timestamps' do
+        before { subject.save! }
+
+        it 'created at' do
+          expect(spree_order.created_at).to eq shopify_order.created_at
+        end
+
+        it 'updated at' do
+          expect(spree_order.updated_at).to eq shopify_order.updated_at
+        end
+      end
+    end
+  end
+end

--- a/spec/services/shopify_import/data_parsers/orders/base_data_spec.rb
+++ b/spec/services/shopify_import/data_parsers/orders/base_data_spec.rb
@@ -1,0 +1,83 @@
+require 'spec_helper'
+
+RSpec.describe ShopifyImport::DataParsers::Orders::BaseData, type: :service do
+  let(:shopify_order) { create(:shopify_order) }
+  let(:shopify_transaction) { create(:shopify_transaction, order: shopify_order) }
+  subject { described_class.new(shopify_order) }
+
+  describe '#user' do
+    let(:user) { create(:user) }
+    let!(:shopify_data_feed) do
+      create(:shopify_data_feed,
+             spree_object: user,
+             shopify_object_id: shopify_order.customer.id,
+             shopify_object_type: 'ShopifyAPI::Customer')
+    end
+
+    it 'returns spree user' do
+      expect(subject.user).to eq user
+    end
+
+    context 'where user is not imported' do
+      it 'creates new user'
+    end
+  end
+
+  describe '#order_attributes' do
+    let(:base_order_attributes) do
+      {
+        number: shopify_order.order_number,
+        email: shopify_order.email,
+        channel: I18n.t('shopify'),
+        currency: shopify_order.currency,
+        note: shopify_order.note,
+        confirmation_delivered: shopify_order.confirmed,
+        last_ip_address: shopify_order.browser_ip,
+        item_count: shopify_order.line_items.sum(&:quantity)
+      }
+    end
+    let(:order_totals) do
+      {
+        total: shopify_order.total_price,
+        item_total: shopify_order.total_line_items_price,
+        additional_tax_total: shopify_order.total_tax,
+        promo_total: -shopify_order.total_discounts.to_d,
+        payment_total: shopify_transaction.amount,
+        shipment_total: shopify_order.shipping_lines.sum(&:price)
+      }
+    end
+    let(:order_states) do
+      {
+        state: 'complete',
+        payment_state: 'paid',
+        shipment_state: 'shipped'
+      }
+    end
+    let(:result) do
+      [base_order_attributes, order_totals, order_states].inject(&:merge)
+    end
+
+    before do
+      allow_any_instance_of(ShopifyAPI::Order).to receive(:transactions).and_return([shopify_transaction])
+    end
+
+    it 'prepare hash of order attributes' do
+      expect(subject.order_attributes).to eq result
+    end
+
+    context 'other order states'
+  end
+
+  context '#order_timestamps' do
+    let(:order_timestamps) do
+      {
+        created_at: shopify_order.created_at,
+        updated_at: shopify_order.updated_at
+      }
+    end
+
+    it 'prepare hash of order timestamps' do
+      expect(subject.order_timestamps).to eq order_timestamps
+    end
+  end
+end

--- a/spec/vcr/shopify/base_order.yml
+++ b/spec/vcr/shopify/base_order.yml
@@ -1,0 +1,406 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://spree-shopify-importer-test-store.myshopify.com/admin/orders/5182437124.json
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Basic MGE5NDQ1YjdiMDY3NzE5YTBhZjAyNDYxMDM2NGVlMzQ6ODAwZjk3ZDZlYTFhNzY4MDQ4ODUxY2RkOTlhOTEwMWE=
+      Accept:
+      - application/json
+      User-Agent:
+      - ShopifyAPI/4.9.0 ActiveResource/5.0.0 Ruby/2.3.4
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Sun, 25 Jun 2017 11:36:09 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Sorting-Hat-Podid:
+      - '3'
+      X-Sorting-Hat-Podid-Cached:
+      - '1'
+      X-Sorting-Hat-Shopid:
+      - '20513691'
+      X-Sorting-Hat-Section:
+      - pod
+      X-Sorting-Hat-Shopid-Cached:
+      - '1'
+      Vary:
+      - Accept-Encoding
+      Referrer-Policy:
+      - origin-when-cross-origin
+      X-Frame-Options:
+      - DENY
+      X-Shopid:
+      - '20513691'
+      X-Shardid:
+      - '3'
+      X-Shopify-Shop-Api-Call-Limit:
+      - 1/40
+      Http-X-Shopify-Shop-Api-Call-Limit:
+      - 1/40
+      X-Stats-Userid:
+      - '0'
+      X-Stats-Apiclientid:
+      - '1680429'
+      X-Stats-Apipermissionid:
+      - '52824317'
+      X-Request-Id:
+      - c89c9d1f-218b-45b9-bbe2-8050f82a44bb
+      Content-Security-Policy:
+      - 'default-src ''self'' data: blob: ''unsafe-inline'' ''unsafe-eval'' https://*
+        shopify-pos://*; block-all-mixed-content; child-src ''self'' https://* shopify-pos://*;
+        connect-src ''self'' wss://* https://*; script-src https://cdn.shopify.com
+        https://checkout.shopifycs.com https://js-agent.newrelic.com https://bam.nr-data.net
+        https://dme0ih8comzn4.cloudfront.net https://api.stripe.com https://mpsnare.iesnare.com
+        https://appcenter.intuit.com https://www.paypal.com https://maps.googleapis.com
+        https://stats.g.doubleclick.net https://www.google-analytics.com https://visitors.shopify.com
+        https://v.shopify.com https://widget.intercom.io https://js.intercomcdn.com
+        ''self'' ''unsafe-inline'' ''unsafe-eval''; upgrade-insecure-requests; report-uri
+        /csp-report?source%5Baction%5D=show&source%5Bapp%5D=Shopify&source%5Bcontroller%5D=admin%2Forders&source%5Bsection%5D=admin&source%5Buuid%5D=c89c9d1f-218b-45b9-bbe2-8050f82a44bb'
+      X-Content-Type-Options:
+      - nosniff
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Xss-Protection:
+      - 1; mode=block; report=/xss-report?source%5Baction%5D=show&source%5Bapp%5D=Shopify&source%5Bcontroller%5D=admin%2Forders&source%5Bsection%5D=admin&source%5Buuid%5D=c89c9d1f-218b-45b9-bbe2-8050f82a44bb
+      P3p:
+      - CP="NOI DSP COR NID ADMa OPTa OUR NOR"
+      X-Dc:
+      - ash
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        eyJvcmRlciI6eyJpZCI6NTE4MjQzNzEyNCwiZW1haWwiOiJleGFtcGxlQGV4
+        YW1wbGUuY29tIiwiY2xvc2VkX2F0IjpudWxsLCJjcmVhdGVkX2F0IjoiMjAx
+        Ny0wNi0xNVQxNzo1MjoyOCswMjowMCIsInVwZGF0ZWRfYXQiOiIyMDE3LTA2
+        LTI1VDEzOjM1OjUxKzAyOjAwIiwibnVtYmVyIjoxLCJub3RlIjpudWxsLCJ0
+        b2tlbiI6IjY0NjA5ZjA1OTIwZWJiMmM1NTQ2NjIyNGEyMWE5NmYzIiwiZ2F0
+        ZXdheSI6ImJvZ3VzIiwidGVzdCI6dHJ1ZSwidG90YWxfcHJpY2UiOiI0NzAu
+        MDAiLCJzdWJ0b3RhbF9wcmljZSI6IjQ1MC4wMCIsInRvdGFsX3dlaWdodCI6
+        MCwidG90YWxfdGF4IjoiMC4wMCIsInRheGVzX2luY2x1ZGVkIjp0cnVlLCJj
+        dXJyZW5jeSI6IkVVUiIsImZpbmFuY2lhbF9zdGF0dXMiOiJwYWlkIiwiY29u
+        ZmlybWVkIjp0cnVlLCJ0b3RhbF9kaXNjb3VudHMiOiIwLjAwIiwidG90YWxf
+        bGluZV9pdGVtc19wcmljZSI6IjQ1MC4wMCIsImNhcnRfdG9rZW4iOiI4MjU0
+        ZTNkYmMxZjZhYWJkOTQ5ODk0ZTcwMjZjMGZmMCIsImJ1eWVyX2FjY2VwdHNf
+        bWFya2V0aW5nIjpmYWxzZSwibmFtZSI6IiMxMDAxIiwicmVmZXJyaW5nX3Np
+        dGUiOiIiLCJsYW5kaW5nX3NpdGUiOiJcL2FkbWluXC9hdXRoXC93cm9uZ190
+        b2tlbiIsImNhbmNlbGxlZF9hdCI6bnVsbCwiY2FuY2VsX3JlYXNvbiI6bnVs
+        bCwidG90YWxfcHJpY2VfdXNkIjoiNTI3LjAxIiwiY2hlY2tvdXRfdG9rZW4i
+        OiIxNjVmM2NkMTIwMTMyNmNkM2FmZGUyYzU1MzJmMzE5OSIsInJlZmVyZW5j
+        ZSI6bnVsbCwidXNlcl9pZCI6bnVsbCwibG9jYXRpb25faWQiOm51bGwsInNv
+        dXJjZV9pZGVudGlmaWVyIjpudWxsLCJzb3VyY2VfdXJsIjpudWxsLCJwcm9j
+        ZXNzZWRfYXQiOiIyMDE3LTA2LTE1VDE3OjUyOjI4KzAyOjAwIiwiZGV2aWNl
+        X2lkIjpudWxsLCJwaG9uZSI6bnVsbCwiYnJvd3Nlcl9pcCI6bnVsbCwibGFu
+        ZGluZ19zaXRlX3JlZiI6bnVsbCwib3JkZXJfbnVtYmVyIjoxMDAxLCJkaXNj
+        b3VudF9jb2RlcyI6W10sIm5vdGVfYXR0cmlidXRlcyI6W10sInBheW1lbnRf
+        Z2F0ZXdheV9uYW1lcyI6WyJib2d1cyJdLCJwcm9jZXNzaW5nX21ldGhvZCI6
+        ImRpcmVjdCIsImNoZWNrb3V0X2lkIjoxNTM0ODIwMjY5Miwic291cmNlX25h
+        bWUiOiJ3ZWIiLCJmdWxmaWxsbWVudF9zdGF0dXMiOiJwYXJ0aWFsIiwidGF4
+        X2xpbmVzIjpbXSwidGFncyI6IiIsImNvbnRhY3RfZW1haWwiOiJleGFtcGxl
+        QGV4YW1wbGUuY29tIiwib3JkZXJfc3RhdHVzX3VybCI6Imh0dHBzOlwvXC9j
+        aGVja291dC5zaG9waWZ5LmNvbVwvMjA1MTM2OTFcL2NoZWNrb3V0c1wvMTY1
+        ZjNjZDEyMDEzMjZjZDNhZmRlMmM1NTMyZjMxOTlcL3RoYW5rX3lvdV90b2tl
+        bj9rZXk9ZWFhMWJkNTlhZDRhMWFiMzAyZjQ4NjcyZjllZTM4MzMiLCJsaW5l
+        X2l0ZW1zIjpbeyJpZCI6MTAwNjkyOTA3NTYsInZhcmlhbnRfaWQiOjQxNzMz
+        MzQ3NTg4LCJ0aXRsZSI6Ik5vIHZhcmlhbnRzIiwicXVhbnRpdHkiOjMsInBy
+        aWNlIjoiMTUwLjAwIiwiZ3JhbXMiOjAsInNrdSI6IiIsInZhcmlhbnRfdGl0
+        bGUiOiIiLCJ2ZW5kb3IiOiJTcHJlZSBTaG9waWZ5IEltcG9ydGVyIFRlc3Qg
+        U3RvcmUiLCJmdWxmaWxsbWVudF9zZXJ2aWNlIjoibWFudWFsIiwicHJvZHVj
+        dF9pZCI6MTEwNTUxNjkwMjgsInJlcXVpcmVzX3NoaXBwaW5nIjp0cnVlLCJ0
+        YXhhYmxlIjp0cnVlLCJnaWZ0X2NhcmQiOmZhbHNlLCJuYW1lIjoiTm8gdmFy
+        aWFudHMiLCJ2YXJpYW50X2ludmVudG9yeV9tYW5hZ2VtZW50IjpudWxsLCJw
+        cm9wZXJ0aWVzIjpbXSwicHJvZHVjdF9leGlzdHMiOnRydWUsImZ1bGZpbGxh
+        YmxlX3F1YW50aXR5IjowLCJ0b3RhbF9kaXNjb3VudCI6IjAuMDAiLCJmdWxm
+        aWxsbWVudF9zdGF0dXMiOiJmdWxmaWxsZWQiLCJ0YXhfbGluZXMiOltdLCJv
+        cmlnaW5fbG9jYXRpb24iOnsiaWQiOjMxMzI0OTkwNzYsImNvdW50cnlfY29k
+        ZSI6IkhSIiwicHJvdmluY2VfY29kZSI6IiIsIm5hbWUiOiJTcHJlZSBTaG9w
+        aWZ5IEltcG9ydGVyIFRlc3QgU3RvcmUiLCJhZGRyZXNzMSI6Ik9zamVja2Eg
+        NTgiLCJhZGRyZXNzMiI6IiIsImNpdHkiOiJTcGxpdCIsInppcCI6IjIxMDAw
+        In0sImRlc3RpbmF0aW9uX2xvY2F0aW9uIjp7ImlkIjozMTMyNTAwNDIwLCJj
+        b3VudHJ5X2NvZGUiOiJQTCIsInByb3ZpbmNlX2NvZGUiOiIiLCJuYW1lIjoi
+        UGV0ZXIgUGFuIiwiYWRkcmVzczEiOiJTb21lIFN0cmVldCIsImFkZHJlc3My
+        IjoiNSIsImNpdHkiOiJXYXJzemF3YSIsInppcCI6IjAyLTc3NyJ9fSx7Imlk
+        IjoxMDA2OTI5MDgyMCwidmFyaWFudF9pZCI6NDIwNzc0OTIxMDAsInRpdGxl
+        IjoiUHJvZHVjdCB3aXRoIHNpbmdsZSB2YXJpYW50IiwicXVhbnRpdHkiOjUs
+        InByaWNlIjoiMC4wMCIsImdyYW1zIjowLCJza3UiOiIiLCJ2YXJpYW50X3Rp
+        dGxlIjoiTSIsInZlbmRvciI6IlNwcmVlIFNob3BpZnkgSW1wb3J0ZXIgVGVz
+        dCBTdG9yZSIsImZ1bGZpbGxtZW50X3NlcnZpY2UiOiJtYW51YWwiLCJwcm9k
+        dWN0X2lkIjoxMTEwMTUyNTgyOCwicmVxdWlyZXNfc2hpcHBpbmciOnRydWUs
+        InRheGFibGUiOnRydWUsImdpZnRfY2FyZCI6ZmFsc2UsIm5hbWUiOiJQcm9k
+        dWN0IHdpdGggc2luZ2xlIHZhcmlhbnQgLSBNIiwidmFyaWFudF9pbnZlbnRv
+        cnlfbWFuYWdlbWVudCI6bnVsbCwicHJvcGVydGllcyI6W10sInByb2R1Y3Rf
+        ZXhpc3RzIjp0cnVlLCJmdWxmaWxsYWJsZV9xdWFudGl0eSI6MiwidG90YWxf
+        ZGlzY291bnQiOiIwLjAwIiwiZnVsZmlsbG1lbnRfc3RhdHVzIjoicGFydGlh
+        bCIsInRheF9saW5lcyI6W10sIm9yaWdpbl9sb2NhdGlvbiI6eyJpZCI6MzEz
+        MjQ5OTA3NiwiY291bnRyeV9jb2RlIjoiSFIiLCJwcm92aW5jZV9jb2RlIjoi
+        IiwibmFtZSI6IlNwcmVlIFNob3BpZnkgSW1wb3J0ZXIgVGVzdCBTdG9yZSIs
+        ImFkZHJlc3MxIjoiT3NqZWNrYSA1OCIsImFkZHJlc3MyIjoiIiwiY2l0eSI6
+        IlNwbGl0IiwiemlwIjoiMjEwMDAifSwiZGVzdGluYXRpb25fbG9jYXRpb24i
+        OnsiaWQiOjMxMzI1MDA0MjAsImNvdW50cnlfY29kZSI6IlBMIiwicHJvdmlu
+        Y2VfY29kZSI6IiIsIm5hbWUiOiJQZXRlciBQYW4iLCJhZGRyZXNzMSI6IlNv
+        bWUgU3RyZWV0IiwiYWRkcmVzczIiOiI1IiwiY2l0eSI6IldhcnN6YXdhIiwi
+        emlwIjoiMDItNzc3In19XSwic2hpcHBpbmdfbGluZXMiOlt7ImlkIjo0MjI1
+        MzI0MDM2LCJ0aXRsZSI6IkludGVybmF0aW9uYWwgU2hpcHBpbmciLCJwcmlj
+        ZSI6IjIwLjAwIiwiY29kZSI6IkludGVybmF0aW9uYWwgU2hpcHBpbmciLCJz
+        b3VyY2UiOiJzaG9waWZ5IiwicGhvbmUiOm51bGwsInJlcXVlc3RlZF9mdWxm
+        aWxsbWVudF9zZXJ2aWNlX2lkIjpudWxsLCJkZWxpdmVyeV9jYXRlZ29yeSI6
+        bnVsbCwiY2Fycmllcl9pZGVudGlmaWVyIjpudWxsLCJ0YXhfbGluZXMiOltd
+        fV0sImJpbGxpbmdfYWRkcmVzcyI6eyJmaXJzdF9uYW1lIjoiUGV0ZXIiLCJh
+        ZGRyZXNzMSI6IlNvbWUgU3RyZWV0IiwicGhvbmUiOm51bGwsImNpdHkiOiJX
+        YXJzemF3YSIsInppcCI6IjAyLTc3NyIsInByb3ZpbmNlIjpudWxsLCJjb3Vu
+        dHJ5IjoiUG9sYW5kIiwibGFzdF9uYW1lIjoiUGFuIiwiYWRkcmVzczIiOiI1
+        IiwiY29tcGFueSI6bnVsbCwibGF0aXR1ZGUiOjUyLjE2MDQwOCwibG9uZ2l0
+        dWRlIjoyMS4wNTQ1MDI0LCJuYW1lIjoiUGV0ZXIgUGFuIiwiY291bnRyeV9j
+        b2RlIjoiUEwiLCJwcm92aW5jZV9jb2RlIjpudWxsfSwic2hpcHBpbmdfYWRk
+        cmVzcyI6eyJmaXJzdF9uYW1lIjoiUGV0ZXIiLCJhZGRyZXNzMSI6IlNvbWUg
+        U3RyZWV0IiwicGhvbmUiOm51bGwsImNpdHkiOiJXYXJzemF3YSIsInppcCI6
+        IjAyLTc3NyIsInByb3ZpbmNlIjpudWxsLCJjb3VudHJ5IjoiUG9sYW5kIiwi
+        bGFzdF9uYW1lIjoiUGFuIiwiYWRkcmVzczIiOiI1IiwiY29tcGFueSI6bnVs
+        bCwibGF0aXR1ZGUiOjUyLjE2MDQwOCwibG9uZ2l0dWRlIjoyMS4wNTQ1MDI0
+        LCJuYW1lIjoiUGV0ZXIgUGFuIiwiY291bnRyeV9jb2RlIjoiUEwiLCJwcm92
+        aW5jZV9jb2RlIjpudWxsfSwiZnVsZmlsbG1lbnRzIjpbeyJpZCI6NDQ1MzI2
+        MDU0OCwib3JkZXJfaWQiOjUxODI0MzcxMjQsInN0YXR1cyI6InN1Y2Nlc3Mi
+        LCJjcmVhdGVkX2F0IjoiMjAxNy0wNi0xNVQxNzo1NDoyMyswMjowMCIsInNl
+        cnZpY2UiOiJtYW51YWwiLCJ1cGRhdGVkX2F0IjoiMjAxNy0wNi0xNVQxNzo1
+        NDoyMyswMjowMCIsInRyYWNraW5nX2NvbXBhbnkiOiJESEwgZUNvbW1lcmNl
+        Iiwic2hpcG1lbnRfc3RhdHVzIjpudWxsLCJ0cmFja2luZ19udW1iZXIiOiIy
+        MTEyMzEyMzEyMzIxMyIsInRyYWNraW5nX251bWJlcnMiOlsiMjExMjMxMjMx
+        MjMyMTMiXSwidHJhY2tpbmdfdXJsIjoiaHR0cDpcL1wvd2VidHJhY2suZGhs
+        Z2xvYmFsbWFpbC5jb21cLz90cmFja2luZ251bWJlcj0yMTEyMzEyMzEyMzIx
+        MyIsInRyYWNraW5nX3VybHMiOlsiaHR0cDpcL1wvd2VidHJhY2suZGhsZ2xv
+        YmFsbWFpbC5jb21cLz90cmFja2luZ251bWJlcj0yMTEyMzEyMzEyMzIxMyJd
+        LCJyZWNlaXB0Ijp7fSwibGluZV9pdGVtcyI6W3siaWQiOjEwMDY5MjkwODIw
+        LCJ2YXJpYW50X2lkIjo0MjA3NzQ5MjEwMCwidGl0bGUiOiJQcm9kdWN0IHdp
+        dGggc2luZ2xlIHZhcmlhbnQiLCJxdWFudGl0eSI6MSwicHJpY2UiOiIwLjAw
+        IiwiZ3JhbXMiOjAsInNrdSI6IiIsInZhcmlhbnRfdGl0bGUiOiJNIiwidmVu
+        ZG9yIjoiU3ByZWUgU2hvcGlmeSBJbXBvcnRlciBUZXN0IFN0b3JlIiwiZnVs
+        ZmlsbG1lbnRfc2VydmljZSI6Im1hbnVhbCIsInByb2R1Y3RfaWQiOjExMTAx
+        NTI1ODI4LCJyZXF1aXJlc19zaGlwcGluZyI6dHJ1ZSwidGF4YWJsZSI6dHJ1
+        ZSwiZ2lmdF9jYXJkIjpmYWxzZSwibmFtZSI6IlByb2R1Y3Qgd2l0aCBzaW5n
+        bGUgdmFyaWFudCAtIE0iLCJ2YXJpYW50X2ludmVudG9yeV9tYW5hZ2VtZW50
+        IjpudWxsLCJwcm9wZXJ0aWVzIjpbXSwicHJvZHVjdF9leGlzdHMiOnRydWUs
+        ImZ1bGZpbGxhYmxlX3F1YW50aXR5IjoyLCJ0b3RhbF9kaXNjb3VudCI6IjAu
+        MDAiLCJmdWxmaWxsbWVudF9zdGF0dXMiOiJwYXJ0aWFsIiwidGF4X2xpbmVz
+        IjpbXSwib3JpZ2luX2xvY2F0aW9uIjp7ImlkIjozMTMyNDk5MDc2LCJjb3Vu
+        dHJ5X2NvZGUiOiJIUiIsInByb3ZpbmNlX2NvZGUiOiIiLCJuYW1lIjoiU3By
+        ZWUgU2hvcGlmeSBJbXBvcnRlciBUZXN0IFN0b3JlIiwiYWRkcmVzczEiOiJP
+        c2plY2thIDU4IiwiYWRkcmVzczIiOiIiLCJjaXR5IjoiU3BsaXQiLCJ6aXAi
+        OiIyMTAwMCJ9LCJkZXN0aW5hdGlvbl9sb2NhdGlvbiI6eyJpZCI6MzEzMjUw
+        MDQyMCwiY291bnRyeV9jb2RlIjoiUEwiLCJwcm92aW5jZV9jb2RlIjoiIiwi
+        bmFtZSI6IlBldGVyIFBhbiIsImFkZHJlc3MxIjoiU29tZSBTdHJlZXQiLCJh
+        ZGRyZXNzMiI6IjUiLCJjaXR5IjoiV2Fyc3phd2EiLCJ6aXAiOiIwMi03Nzci
+        fX1dfSx7ImlkIjo0NDUzMjU4NzU2LCJvcmRlcl9pZCI6NTE4MjQzNzEyNCwi
+        c3RhdHVzIjoic3VjY2VzcyIsImNyZWF0ZWRfYXQiOiIyMDE3LTA2LTE1VDE3
+        OjUzOjQ0KzAyOjAwIiwic2VydmljZSI6Im1hbnVhbCIsInVwZGF0ZWRfYXQi
+        OiIyMDE3LTA2LTE1VDE3OjUzOjQ1KzAyOjAwIiwidHJhY2tpbmdfY29tcGFu
+        eSI6IkNhbmFkYSBQb3N0Iiwic2hpcG1lbnRfc3RhdHVzIjpudWxsLCJ0cmFj
+        a2luZ19udW1iZXIiOiIxMTIzMjEzMTI0MTIzMjEzIiwidHJhY2tpbmdfbnVt
+        YmVycyI6WyIxMTIzMjEzMTI0MTIzMjEzIl0sInRyYWNraW5nX3VybCI6Imh0
+        dHBzOlwvXC93d3cuY2FuYWRhcG9zdC5jYVwvY3BvdG9vbHNcL2FwcHNcL3Ry
+        YWNrXC9wZXJzb25hbFwvZmluZEJ5VHJhY2tOdW1iZXI/dHJhY2tpbmdOdW1i
+        ZXI9MTEyMzIxMzEyNDEyMzIxMyIsInRyYWNraW5nX3VybHMiOlsiaHR0cHM6
+        XC9cL3d3dy5jYW5hZGFwb3N0LmNhXC9jcG90b29sc1wvYXBwc1wvdHJhY2tc
+        L3BlcnNvbmFsXC9maW5kQnlUcmFja051bWJlcj90cmFja2luZ051bWJlcj0x
+        MTIzMjEzMTI0MTIzMjEzIl0sInJlY2VpcHQiOnt9LCJsaW5lX2l0ZW1zIjpb
+        eyJpZCI6MTAwNjkyOTA3NTYsInZhcmlhbnRfaWQiOjQxNzMzMzQ3NTg4LCJ0
+        aXRsZSI6Ik5vIHZhcmlhbnRzIiwicXVhbnRpdHkiOjMsInByaWNlIjoiMTUw
+        LjAwIiwiZ3JhbXMiOjAsInNrdSI6IiIsInZhcmlhbnRfdGl0bGUiOiIiLCJ2
+        ZW5kb3IiOiJTcHJlZSBTaG9waWZ5IEltcG9ydGVyIFRlc3QgU3RvcmUiLCJm
+        dWxmaWxsbWVudF9zZXJ2aWNlIjoibWFudWFsIiwicHJvZHVjdF9pZCI6MTEw
+        NTUxNjkwMjgsInJlcXVpcmVzX3NoaXBwaW5nIjp0cnVlLCJ0YXhhYmxlIjp0
+        cnVlLCJnaWZ0X2NhcmQiOmZhbHNlLCJuYW1lIjoiTm8gdmFyaWFudHMiLCJ2
+        YXJpYW50X2ludmVudG9yeV9tYW5hZ2VtZW50IjpudWxsLCJwcm9wZXJ0aWVz
+        IjpbXSwicHJvZHVjdF9leGlzdHMiOnRydWUsImZ1bGZpbGxhYmxlX3F1YW50
+        aXR5IjowLCJ0b3RhbF9kaXNjb3VudCI6IjAuMDAiLCJmdWxmaWxsbWVudF9z
+        dGF0dXMiOiJmdWxmaWxsZWQiLCJ0YXhfbGluZXMiOltdLCJvcmlnaW5fbG9j
+        YXRpb24iOnsiaWQiOjMxMzI0OTkwNzYsImNvdW50cnlfY29kZSI6IkhSIiwi
+        cHJvdmluY2VfY29kZSI6IiIsIm5hbWUiOiJTcHJlZSBTaG9waWZ5IEltcG9y
+        dGVyIFRlc3QgU3RvcmUiLCJhZGRyZXNzMSI6Ik9zamVja2EgNTgiLCJhZGRy
+        ZXNzMiI6IiIsImNpdHkiOiJTcGxpdCIsInppcCI6IjIxMDAwIn0sImRlc3Rp
+        bmF0aW9uX2xvY2F0aW9uIjp7ImlkIjozMTMyNTAwNDIwLCJjb3VudHJ5X2Nv
+        ZGUiOiJQTCIsInByb3ZpbmNlX2NvZGUiOiIiLCJuYW1lIjoiUGV0ZXIgUGFu
+        IiwiYWRkcmVzczEiOiJTb21lIFN0cmVldCIsImFkZHJlc3MyIjoiNSIsImNp
+        dHkiOiJXYXJzemF3YSIsInppcCI6IjAyLTc3NyJ9fSx7ImlkIjoxMDA2OTI5
+        MDgyMCwidmFyaWFudF9pZCI6NDIwNzc0OTIxMDAsInRpdGxlIjoiUHJvZHVj
+        dCB3aXRoIHNpbmdsZSB2YXJpYW50IiwicXVhbnRpdHkiOjIsInByaWNlIjoi
+        MC4wMCIsImdyYW1zIjowLCJza3UiOiIiLCJ2YXJpYW50X3RpdGxlIjoiTSIs
+        InZlbmRvciI6IlNwcmVlIFNob3BpZnkgSW1wb3J0ZXIgVGVzdCBTdG9yZSIs
+        ImZ1bGZpbGxtZW50X3NlcnZpY2UiOiJtYW51YWwiLCJwcm9kdWN0X2lkIjox
+        MTEwMTUyNTgyOCwicmVxdWlyZXNfc2hpcHBpbmciOnRydWUsInRheGFibGUi
+        OnRydWUsImdpZnRfY2FyZCI6ZmFsc2UsIm5hbWUiOiJQcm9kdWN0IHdpdGgg
+        c2luZ2xlIHZhcmlhbnQgLSBNIiwidmFyaWFudF9pbnZlbnRvcnlfbWFuYWdl
+        bWVudCI6bnVsbCwicHJvcGVydGllcyI6W10sInByb2R1Y3RfZXhpc3RzIjp0
+        cnVlLCJmdWxmaWxsYWJsZV9xdWFudGl0eSI6MiwidG90YWxfZGlzY291bnQi
+        OiIwLjAwIiwiZnVsZmlsbG1lbnRfc3RhdHVzIjoicGFydGlhbCIsInRheF9s
+        aW5lcyI6W10sIm9yaWdpbl9sb2NhdGlvbiI6eyJpZCI6MzEzMjQ5OTA3Niwi
+        Y291bnRyeV9jb2RlIjoiSFIiLCJwcm92aW5jZV9jb2RlIjoiIiwibmFtZSI6
+        IlNwcmVlIFNob3BpZnkgSW1wb3J0ZXIgVGVzdCBTdG9yZSIsImFkZHJlc3Mx
+        IjoiT3NqZWNrYSA1OCIsImFkZHJlc3MyIjoiIiwiY2l0eSI6IlNwbGl0Iiwi
+        emlwIjoiMjEwMDAifSwiZGVzdGluYXRpb25fbG9jYXRpb24iOnsiaWQiOjMx
+        MzI1MDA0MjAsImNvdW50cnlfY29kZSI6IlBMIiwicHJvdmluY2VfY29kZSI6
+        IiIsIm5hbWUiOiJQZXRlciBQYW4iLCJhZGRyZXNzMSI6IlNvbWUgU3RyZWV0
+        IiwiYWRkcmVzczIiOiI1IiwiY2l0eSI6IldhcnN6YXdhIiwiemlwIjoiMDIt
+        Nzc3In19XX1dLCJjbGllbnRfZGV0YWlscyI6eyJicm93c2VyX2lwIjoiOTQu
+        NzUuOTYuOTgiLCJhY2NlcHRfbGFuZ3VhZ2UiOiJwbC1QTCxwbDtxPTAuOCxl
+        bi1VUztxPTAuNixlbjtxPTAuNCIsInVzZXJfYWdlbnQiOiJNb3ppbGxhXC81
+        LjAgKE1hY2ludG9zaDsgSW50ZWwgTWFjIE9TIFggMTBfMTJfNCkgQXBwbGVX
+        ZWJLaXRcLzUzNy4zNiAoS0hUTUwsIGxpa2UgR2Vja28pIENocm9tZVwvNTgu
+        MC4zMDI5LjExMCBTYWZhcmlcLzUzNy4zNiIsInNlc3Npb25faGFzaCI6bnVs
+        bCwiYnJvd3Nlcl93aWR0aCI6MTQ0MCwiYnJvd3Nlcl9oZWlnaHQiOjgyNn0s
+        InJlZnVuZHMiOltdLCJwYXltZW50X2RldGFpbHMiOnsiY3JlZGl0X2NhcmRf
+        YmluIjoiMSIsImF2c19yZXN1bHRfY29kZSI6bnVsbCwiY3Z2X3Jlc3VsdF9j
+        b2RlIjpudWxsLCJjcmVkaXRfY2FyZF9udW1iZXIiOiLigKLigKLigKLigKIg
+        4oCi4oCi4oCi4oCiIOKAouKAouKAouKAoiAxIiwiY3JlZGl0X2NhcmRfY29t
+        cGFueSI6IkJvZ3VzIn0sImN1c3RvbWVyIjp7ImlkIjo1NzAxNzM2ODM2LCJl
+        bWFpbCI6ImV4YW1wbGVAZXhhbXBsZS5jb20iLCJhY2NlcHRzX21hcmtldGlu
+        ZyI6ZmFsc2UsImNyZWF0ZWRfYXQiOiIyMDE3LTA2LTE1VDE3OjUxOjQ3KzAy
+        OjAwIiwidXBkYXRlZF9hdCI6IjIwMTctMDYtMjVUMTM6MzU6NTErMDI6MDAi
+        LCJmaXJzdF9uYW1lIjoiUGV0ZXIiLCJsYXN0X25hbWUiOiJQYW4iLCJvcmRl
+        cnNfY291bnQiOjAsInN0YXRlIjoiZGlzYWJsZWQiLCJ0b3RhbF9zcGVudCI6
+        IjAuMDAiLCJsYXN0X29yZGVyX2lkIjpudWxsLCJub3RlIjpudWxsLCJ2ZXJp
+        ZmllZF9lbWFpbCI6dHJ1ZSwibXVsdGlwYXNzX2lkZW50aWZpZXIiOm51bGws
+        InRheF9leGVtcHQiOmZhbHNlLCJwaG9uZSI6bnVsbCwidGFncyI6IiIsImxh
+        c3Rfb3JkZXJfbmFtZSI6bnVsbCwiZGVmYXVsdF9hZGRyZXNzIjp7ImlkIjo1
+        OTg1NTAyMjEyLCJmaXJzdF9uYW1lIjoiUGV0ZXIiLCJsYXN0X25hbWUiOiJQ
+        YW4iLCJjb21wYW55IjpudWxsLCJhZGRyZXNzMSI6IlNvbWUgU3RyZWV0Iiwi
+        YWRkcmVzczIiOiI1IiwiY2l0eSI6IldhcnN6YXdhIiwicHJvdmluY2UiOm51
+        bGwsImNvdW50cnkiOiJQb2xhbmQiLCJ6aXAiOiIwMi03NzciLCJwaG9uZSI6
+        bnVsbCwibmFtZSI6IlBldGVyIFBhbiIsInByb3ZpbmNlX2NvZGUiOm51bGws
+        ImNvdW50cnlfY29kZSI6IlBMIiwiY291bnRyeV9uYW1lIjoiUG9sYW5kIiwi
+        ZGVmYXVsdCI6dHJ1ZX19fX0=
+    http_version: 
+  recorded_at: Sun, 25 Jun 2017 11:36:11 GMT
+- request:
+    method: get
+    uri: https://spree-shopify-importer-test-store.myshopify.com/admin/orders/5182437124/transactions.json
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Basic MGE5NDQ1YjdiMDY3NzE5YTBhZjAyNDYxMDM2NGVlMzQ6ODAwZjk3ZDZlYTFhNzY4MDQ4ODUxY2RkOTlhOTEwMWE=
+      Accept:
+      - application/json
+      User-Agent:
+      - ShopifyAPI/4.9.0 ActiveResource/5.0.0 Ruby/2.3.4
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Sun, 25 Jun 2017 11:36:10 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Sorting-Hat-Podid:
+      - '3'
+      X-Sorting-Hat-Podid-Cached:
+      - '1'
+      X-Sorting-Hat-Shopid:
+      - '20513691'
+      X-Sorting-Hat-Section:
+      - pod
+      X-Sorting-Hat-Shopid-Cached:
+      - '1'
+      Vary:
+      - Accept-Encoding
+      Referrer-Policy:
+      - origin-when-cross-origin
+      X-Frame-Options:
+      - DENY
+      X-Shopid:
+      - '20513691'
+      X-Shardid:
+      - '3'
+      X-Shopify-Shop-Api-Call-Limit:
+      - 1/40
+      Http-X-Shopify-Shop-Api-Call-Limit:
+      - 1/40
+      X-Stats-Userid:
+      - '0'
+      X-Stats-Apiclientid:
+      - '1680429'
+      X-Stats-Apipermissionid:
+      - '52824317'
+      X-Request-Id:
+      - c4cc2ab7-70b0-4a8f-b43d-9ad6ad6f92ea
+      Content-Security-Policy:
+      - 'default-src ''self'' data: blob: ''unsafe-inline'' ''unsafe-eval'' https://*
+        shopify-pos://*; block-all-mixed-content; child-src ''self'' https://* shopify-pos://*;
+        connect-src ''self'' wss://* https://*; script-src https://cdn.shopify.com
+        https://checkout.shopifycs.com https://js-agent.newrelic.com https://bam.nr-data.net
+        https://dme0ih8comzn4.cloudfront.net https://api.stripe.com https://mpsnare.iesnare.com
+        https://appcenter.intuit.com https://www.paypal.com https://maps.googleapis.com
+        https://stats.g.doubleclick.net https://www.google-analytics.com https://visitors.shopify.com
+        https://v.shopify.com https://widget.intercom.io https://js.intercomcdn.com
+        ''self'' ''unsafe-inline'' ''unsafe-eval''; upgrade-insecure-requests; report-uri
+        /csp-report?source%5Baction%5D=index&source%5Bapp%5D=Shopify&source%5Bcontroller%5D=admin%2Ftransactions&source%5Bsection%5D=admin&source%5Buuid%5D=c4cc2ab7-70b0-4a8f-b43d-9ad6ad6f92ea'
+      X-Content-Type-Options:
+      - nosniff
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Xss-Protection:
+      - 1; mode=block; report=/xss-report?source%5Baction%5D=index&source%5Bapp%5D=Shopify&source%5Bcontroller%5D=admin%2Ftransactions&source%5Bsection%5D=admin&source%5Buuid%5D=c4cc2ab7-70b0-4a8f-b43d-9ad6ad6f92ea
+      P3p:
+      - CP="NOI DSP COR NID ADMa OPTa OUR NOR"
+      X-Dc:
+      - ash
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        eyJ0cmFuc2FjdGlvbnMiOlt7ImlkIjo1NzMyODIwMTAwLCJvcmRlcl9pZCI6
+        NTE4MjQzNzEyNCwiYW1vdW50IjoiNDcwLjAwIiwia2luZCI6ImF1dGhvcml6
+        YXRpb24iLCJnYXRld2F5IjoiYm9ndXMiLCJzdGF0dXMiOiJzdWNjZXNzIiwi
+        bWVzc2FnZSI6IkJvZ3VzIEdhdGV3YXk6IEZvcmNlZCBzdWNjZXNzIiwiY3Jl
+        YXRlZF9hdCI6IjIwMTctMDYtMTVUMTc6NTI6MjgrMDI6MDAiLCJ0ZXN0Ijp0
+        cnVlLCJhdXRob3JpemF0aW9uIjoiNTM0MzMiLCJjdXJyZW5jeSI6IkVVUiIs
+        ImxvY2F0aW9uX2lkIjpudWxsLCJ1c2VyX2lkIjpudWxsLCJwYXJlbnRfaWQi
+        Om51bGwsImRldmljZV9pZCI6bnVsbCwicmVjZWlwdCI6eyJhdXRob3JpemVk
+        X2Ftb3VudCI6IjQ3MC4wMCJ9LCJlcnJvcl9jb2RlIjpudWxsLCJzb3VyY2Vf
+        bmFtZSI6IndlYiIsInBheW1lbnRfZGV0YWlscyI6eyJjcmVkaXRfY2FyZF9i
+        aW4iOiIxIiwiYXZzX3Jlc3VsdF9jb2RlIjpudWxsLCJjdnZfcmVzdWx0X2Nv
+        ZGUiOm51bGwsImNyZWRpdF9jYXJkX251bWJlciI6IuKAouKAouKAouKAoiDi
+        gKLigKLigKLigKIg4oCi4oCi4oCi4oCiIDEiLCJjcmVkaXRfY2FyZF9jb21w
+        YW55IjoiQm9ndXMifX0seyJpZCI6NTczMjgyMjc4OCwib3JkZXJfaWQiOjUx
+        ODI0MzcxMjQsImFtb3VudCI6IjQ3MC4wMCIsImtpbmQiOiJjYXB0dXJlIiwi
+        Z2F0ZXdheSI6ImJvZ3VzIiwic3RhdHVzIjoic3VjY2VzcyIsIm1lc3NhZ2Ui
+        OiJCb2d1cyBHYXRld2F5OiBGb3JjZWQgc3VjY2VzcyIsImNyZWF0ZWRfYXQi
+        OiIyMDE3LTA2LTE1VDE3OjUzOjI2KzAyOjAwIiwidGVzdCI6dHJ1ZSwiYXV0
+        aG9yaXphdGlvbiI6bnVsbCwiY3VycmVuY3kiOiJFVVIiLCJsb2NhdGlvbl9p
+        ZCI6bnVsbCwidXNlcl9pZCI6bnVsbCwicGFyZW50X2lkIjo1NzMyODIwMTAw
+        LCJkZXZpY2VfaWQiOm51bGwsInJlY2VpcHQiOnsicGFpZF9hbW91bnQiOiI0
+        NzAuMDAifSwiZXJyb3JfY29kZSI6bnVsbCwic291cmNlX25hbWUiOiJ3ZWIi
+        fV19
+    http_version: 
+  recorded_at: Sun, 25 Jun 2017 11:36:12 GMT
+recorded_with: VCR 3.0.3

--- a/spec/vcr/shopify/order/all.yml
+++ b/spec/vcr/shopify/order/all.yml
@@ -1,0 +1,383 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://spree-shopify-importer-test-store.myshopify.com/admin/orders.json?page=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Basic MGE5NDQ1YjdiMDY3NzE5YTBhZjAyNDYxMDM2NGVlMzQ6ODAwZjk3ZDZlYTFhNzY4MDQ4ODUxY2RkOTlhOTEwMWE=
+      Accept:
+      - application/json
+      User-Agent:
+      - ShopifyAPI/4.9.0 ActiveResource/5.0.0 Ruby/2.3.4
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Sat, 17 Jun 2017 14:37:39 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Sorting-Hat-Podid:
+      - '3'
+      X-Sorting-Hat-Podid-Cached:
+      - '0'
+      X-Sorting-Hat-Shopid:
+      - '20513691'
+      X-Sorting-Hat-Section:
+      - pod
+      X-Sorting-Hat-Shopid-Cached:
+      - '0'
+      Vary:
+      - Accept-Encoding
+      Referrer-Policy:
+      - origin-when-cross-origin
+      X-Frame-Options:
+      - DENY
+      X-Shopid:
+      - '20513691'
+      X-Shardid:
+      - '3'
+      X-Shopify-Shop-Api-Call-Limit:
+      - 1/40
+      Http-X-Shopify-Shop-Api-Call-Limit:
+      - 1/40
+      X-Stats-Userid:
+      - '0'
+      X-Stats-Apiclientid:
+      - '1680429'
+      X-Stats-Apipermissionid:
+      - '52824317'
+      X-Request-Id:
+      - f8da1235-c622-4b02-b4aa-0aca6d08f2a5
+      Content-Security-Policy:
+      - 'default-src ''self'' data: blob: ''unsafe-inline'' ''unsafe-eval'' https://*
+        shopify-pos://*; block-all-mixed-content; child-src ''self'' https://* shopify-pos://*;
+        connect-src ''self'' wss://* https://*; script-src https://cdn.shopify.com
+        https://checkout.shopifycs.com https://js-agent.newrelic.com https://bam.nr-data.net
+        https://dme0ih8comzn4.cloudfront.net https://api.stripe.com https://mpsnare.iesnare.com
+        https://appcenter.intuit.com https://www.paypal.com https://maps.googleapis.com
+        https://stats.g.doubleclick.net https://www.google-analytics.com https://visitors.shopify.com
+        https://v.shopify.com https://widget.intercom.io https://js.intercomcdn.com
+        ''self'' ''unsafe-inline'' ''unsafe-eval''; upgrade-insecure-requests; report-uri
+        /csp-report?source%5Baction%5D=index&source%5Bapp%5D=Shopify&source%5Bcontroller%5D=admin%2Forders&source%5Bsection%5D=admin&source%5Buuid%5D=f8da1235-c622-4b02-b4aa-0aca6d08f2a5'
+      X-Content-Type-Options:
+      - nosniff
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Xss-Protection:
+      - 1; mode=block; report=/xss-report?source%5Baction%5D=index&source%5Bapp%5D=Shopify&source%5Bcontroller%5D=admin%2Forders&source%5Bsection%5D=admin&source%5Buuid%5D=f8da1235-c622-4b02-b4aa-0aca6d08f2a5
+      P3p:
+      - CP="NOI DSP COR NID ADMa OPTa OUR NOR"
+      X-Dc:
+      - ash
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        eyJvcmRlcnMiOlt7ImlkIjo1MTgyNDM3MTI0LCJlbWFpbCI6ImFyZ29udXNw
+        aW90ckBnbWFpbC5jb20iLCJjbG9zZWRfYXQiOm51bGwsImNyZWF0ZWRfYXQi
+        OiIyMDE3LTA2LTE1VDE3OjUyOjI4KzAyOjAwIiwidXBkYXRlZF9hdCI6IjIw
+        MTctMDYtMTVUMTc6NTQ6MjMrMDI6MDAiLCJudW1iZXIiOjEsIm5vdGUiOm51
+        bGwsInRva2VuIjoiNjQ2MDlmMDU5MjBlYmIyYzU1NDY2MjI0YTIxYTk2ZjMi
+        LCJnYXRld2F5IjoiYm9ndXMiLCJ0ZXN0Ijp0cnVlLCJ0b3RhbF9wcmljZSI6
+        IjQ3MC4wMCIsInN1YnRvdGFsX3ByaWNlIjoiNDUwLjAwIiwidG90YWxfd2Vp
+        Z2h0IjowLCJ0b3RhbF90YXgiOiIwLjAwIiwidGF4ZXNfaW5jbHVkZWQiOnRy
+        dWUsImN1cnJlbmN5IjoiRVVSIiwiZmluYW5jaWFsX3N0YXR1cyI6InBhaWQi
+        LCJjb25maXJtZWQiOnRydWUsInRvdGFsX2Rpc2NvdW50cyI6IjAuMDAiLCJ0
+        b3RhbF9saW5lX2l0ZW1zX3ByaWNlIjoiNDUwLjAwIiwiY2FydF90b2tlbiI6
+        IjgyNTRlM2RiYzFmNmFhYmQ5NDk4OTRlNzAyNmMwZmYwIiwiYnV5ZXJfYWNj
+        ZXB0c19tYXJrZXRpbmciOmZhbHNlLCJuYW1lIjoiIzEwMDEiLCJyZWZlcnJp
+        bmdfc2l0ZSI6IiIsImxhbmRpbmdfc2l0ZSI6IlwvYWRtaW5cL2F1dGhcL3dy
+        b25nX3Rva2VuIiwiY2FuY2VsbGVkX2F0IjpudWxsLCJjYW5jZWxfcmVhc29u
+        IjpudWxsLCJ0b3RhbF9wcmljZV91c2QiOiI1MjcuMDEiLCJjaGVja291dF90
+        b2tlbiI6IjE2NWYzY2QxMjAxMzI2Y2QzYWZkZTJjNTUzMmYzMTk5IiwicmVm
+        ZXJlbmNlIjpudWxsLCJ1c2VyX2lkIjpudWxsLCJsb2NhdGlvbl9pZCI6bnVs
+        bCwic291cmNlX2lkZW50aWZpZXIiOm51bGwsInNvdXJjZV91cmwiOm51bGws
+        InByb2Nlc3NlZF9hdCI6IjIwMTctMDYtMTVUMTc6NTI6MjgrMDI6MDAiLCJk
+        ZXZpY2VfaWQiOm51bGwsInBob25lIjpudWxsLCJicm93c2VyX2lwIjpudWxs
+        LCJsYW5kaW5nX3NpdGVfcmVmIjpudWxsLCJvcmRlcl9udW1iZXIiOjEwMDEs
+        ImRpc2NvdW50X2NvZGVzIjpbXSwibm90ZV9hdHRyaWJ1dGVzIjpbXSwicGF5
+        bWVudF9nYXRld2F5X25hbWVzIjpbImJvZ3VzIl0sInByb2Nlc3NpbmdfbWV0
+        aG9kIjoiZGlyZWN0IiwiY2hlY2tvdXRfaWQiOjE1MzQ4MjAyNjkyLCJzb3Vy
+        Y2VfbmFtZSI6IndlYiIsImZ1bGZpbGxtZW50X3N0YXR1cyI6InBhcnRpYWwi
+        LCJ0YXhfbGluZXMiOltdLCJ0YWdzIjoiIiwiY29udGFjdF9lbWFpbCI6ImFy
+        Z29udXNwaW90ckBnbWFpbC5jb20iLCJvcmRlcl9zdGF0dXNfdXJsIjoiaHR0
+        cHM6XC9cL2NoZWNrb3V0LnNob3BpZnkuY29tXC8yMDUxMzY5MVwvY2hlY2tv
+        dXRzXC8xNjVmM2NkMTIwMTMyNmNkM2FmZGUyYzU1MzJmMzE5OVwvdGhhbmtf
+        eW91X3Rva2VuP2tleT1lYWExYmQ1OWFkNGExYWIzMDJmNDg2NzJmOWVlMzgz
+        MyIsImxpbmVfaXRlbXMiOlt7ImlkIjoxMDA2OTI5MDc1NiwidmFyaWFudF9p
+        ZCI6NDE3MzMzNDc1ODgsInRpdGxlIjoiTm8gdmFyaWFudHMiLCJxdWFudGl0
+        eSI6MywicHJpY2UiOiIxNTAuMDAiLCJncmFtcyI6MCwic2t1IjoiIiwidmFy
+        aWFudF90aXRsZSI6IiIsInZlbmRvciI6IlNwcmVlIFNob3BpZnkgSW1wb3J0
+        ZXIgVGVzdCBTdG9yZSIsImZ1bGZpbGxtZW50X3NlcnZpY2UiOiJtYW51YWwi
+        LCJwcm9kdWN0X2lkIjoxMTA1NTE2OTAyOCwicmVxdWlyZXNfc2hpcHBpbmci
+        OnRydWUsInRheGFibGUiOnRydWUsImdpZnRfY2FyZCI6ZmFsc2UsIm5hbWUi
+        OiJObyB2YXJpYW50cyIsInZhcmlhbnRfaW52ZW50b3J5X21hbmFnZW1lbnQi
+        Om51bGwsInByb3BlcnRpZXMiOltdLCJwcm9kdWN0X2V4aXN0cyI6dHJ1ZSwi
+        ZnVsZmlsbGFibGVfcXVhbnRpdHkiOjAsInRvdGFsX2Rpc2NvdW50IjoiMC4w
+        MCIsImZ1bGZpbGxtZW50X3N0YXR1cyI6ImZ1bGZpbGxlZCIsInRheF9saW5l
+        cyI6W10sIm9yaWdpbl9sb2NhdGlvbiI6eyJpZCI6MzEzMjQ5OTA3NiwiY291
+        bnRyeV9jb2RlIjoiSFIiLCJwcm92aW5jZV9jb2RlIjoiIiwibmFtZSI6IlNw
+        cmVlIFNob3BpZnkgSW1wb3J0ZXIgVGVzdCBTdG9yZSIsImFkZHJlc3MxIjoi
+        T3NqZWNrYSA1OCIsImFkZHJlc3MyIjoiIiwiY2l0eSI6IlNwbGl0Iiwiemlw
+        IjoiMjEwMDAifSwiZGVzdGluYXRpb25fbG9jYXRpb24iOnsiaWQiOjMxMzI1
+        MDA0MjAsImNvdW50cnlfY29kZSI6IlBMIiwicHJvdmluY2VfY29kZSI6IiIs
+        Im5hbWUiOiJQZXRlciBQYW4iLCJhZGRyZXNzMSI6IlNvbWUgU3RyZWV0Iiwi
+        YWRkcmVzczIiOiI1IiwiY2l0eSI6IldhcnN6YXdhIiwiemlwIjoiMDItNzc3
+        In19LHsiaWQiOjEwMDY5MjkwODIwLCJ2YXJpYW50X2lkIjo0MjA3NzQ5MjEw
+        MCwidGl0bGUiOiJQcm9kdWN0IHdpdGggc2luZ2xlIHZhcmlhbnQiLCJxdWFu
+        dGl0eSI6NSwicHJpY2UiOiIwLjAwIiwiZ3JhbXMiOjAsInNrdSI6IiIsInZh
+        cmlhbnRfdGl0bGUiOiJNIiwidmVuZG9yIjoiU3ByZWUgU2hvcGlmeSBJbXBv
+        cnRlciBUZXN0IFN0b3JlIiwiZnVsZmlsbG1lbnRfc2VydmljZSI6Im1hbnVh
+        bCIsInByb2R1Y3RfaWQiOjExMTAxNTI1ODI4LCJyZXF1aXJlc19zaGlwcGlu
+        ZyI6dHJ1ZSwidGF4YWJsZSI6dHJ1ZSwiZ2lmdF9jYXJkIjpmYWxzZSwibmFt
+        ZSI6IlByb2R1Y3Qgd2l0aCBzaW5nbGUgdmFyaWFudCAtIE0iLCJ2YXJpYW50
+        X2ludmVudG9yeV9tYW5hZ2VtZW50IjpudWxsLCJwcm9wZXJ0aWVzIjpbXSwi
+        cHJvZHVjdF9leGlzdHMiOnRydWUsImZ1bGZpbGxhYmxlX3F1YW50aXR5Ijoy
+        LCJ0b3RhbF9kaXNjb3VudCI6IjAuMDAiLCJmdWxmaWxsbWVudF9zdGF0dXMi
+        OiJwYXJ0aWFsIiwidGF4X2xpbmVzIjpbXSwib3JpZ2luX2xvY2F0aW9uIjp7
+        ImlkIjozMTMyNDk5MDc2LCJjb3VudHJ5X2NvZGUiOiJIUiIsInByb3ZpbmNl
+        X2NvZGUiOiIiLCJuYW1lIjoiU3ByZWUgU2hvcGlmeSBJbXBvcnRlciBUZXN0
+        IFN0b3JlIiwiYWRkcmVzczEiOiJPc2plY2thIDU4IiwiYWRkcmVzczIiOiIi
+        LCJjaXR5IjoiU3BsaXQiLCJ6aXAiOiIyMTAwMCJ9LCJkZXN0aW5hdGlvbl9s
+        b2NhdGlvbiI6eyJpZCI6MzEzMjUwMDQyMCwiY291bnRyeV9jb2RlIjoiUEwi
+        LCJwcm92aW5jZV9jb2RlIjoiIiwibmFtZSI6IlBldGVyIFBhbiIsImFkZHJl
+        c3MxIjoiU29tZSBTdHJlZXQiLCJhZGRyZXNzMiI6IjUiLCJjaXR5IjoiV2Fy
+        c3phd2EiLCJ6aXAiOiIwMi03NzcifX1dLCJzaGlwcGluZ19saW5lcyI6W3si
+        aWQiOjQyMjUzMjQwMzYsInRpdGxlIjoiSW50ZXJuYXRpb25hbCBTaGlwcGlu
+        ZyIsInByaWNlIjoiMjAuMDAiLCJjb2RlIjoiSW50ZXJuYXRpb25hbCBTaGlw
+        cGluZyIsInNvdXJjZSI6InNob3BpZnkiLCJwaG9uZSI6bnVsbCwicmVxdWVz
+        dGVkX2Z1bGZpbGxtZW50X3NlcnZpY2VfaWQiOm51bGwsImRlbGl2ZXJ5X2Nh
+        dGVnb3J5IjpudWxsLCJjYXJyaWVyX2lkZW50aWZpZXIiOm51bGwsInRheF9s
+        aW5lcyI6W119XSwiYmlsbGluZ19hZGRyZXNzIjp7ImZpcnN0X25hbWUiOiJQ
+        ZXRlciIsImFkZHJlc3MxIjoiU29tZSBTdHJlZXQiLCJwaG9uZSI6bnVsbCwi
+        Y2l0eSI6IldhcnN6YXdhIiwiemlwIjoiMDItNzc3IiwicHJvdmluY2UiOm51
+        bGwsImNvdW50cnkiOiJQb2xhbmQiLCJsYXN0X25hbWUiOiJQYW4iLCJhZGRy
+        ZXNzMiI6IjUiLCJjb21wYW55IjpudWxsLCJsYXRpdHVkZSI6NTIuMTYwNDA4
+        LCJsb25naXR1ZGUiOjIxLjA1NDUwMjQsIm5hbWUiOiJQZXRlciBQYW4iLCJj
+        b3VudHJ5X2NvZGUiOiJQTCIsInByb3ZpbmNlX2NvZGUiOm51bGx9LCJzaGlw
+        cGluZ19hZGRyZXNzIjp7ImZpcnN0X25hbWUiOiJQZXRlciIsImFkZHJlc3Mx
+        IjoiU29tZSBTdHJlZXQiLCJwaG9uZSI6bnVsbCwiY2l0eSI6IldhcnN6YXdh
+        IiwiemlwIjoiMDItNzc3IiwicHJvdmluY2UiOm51bGwsImNvdW50cnkiOiJQ
+        b2xhbmQiLCJsYXN0X25hbWUiOiJQYW4iLCJhZGRyZXNzMiI6IjUiLCJjb21w
+        YW55IjpudWxsLCJsYXRpdHVkZSI6NTIuMTYwNDA4LCJsb25naXR1ZGUiOjIx
+        LjA1NDUwMjQsIm5hbWUiOiJQZXRlciBQYW4iLCJjb3VudHJ5X2NvZGUiOiJQ
+        TCIsInByb3ZpbmNlX2NvZGUiOm51bGx9LCJmdWxmaWxsbWVudHMiOlt7Imlk
+        Ijo0NDUzMjYwNTQ4LCJvcmRlcl9pZCI6NTE4MjQzNzEyNCwic3RhdHVzIjoi
+        c3VjY2VzcyIsImNyZWF0ZWRfYXQiOiIyMDE3LTA2LTE1VDE3OjU0OjIzKzAy
+        OjAwIiwic2VydmljZSI6Im1hbnVhbCIsInVwZGF0ZWRfYXQiOiIyMDE3LTA2
+        LTE1VDE3OjU0OjIzKzAyOjAwIiwidHJhY2tpbmdfY29tcGFueSI6IkRITCBl
+        Q29tbWVyY2UiLCJzaGlwbWVudF9zdGF0dXMiOm51bGwsInRyYWNraW5nX251
+        bWJlciI6IjIxMTIzMTIzMTIzMjEzIiwidHJhY2tpbmdfbnVtYmVycyI6WyIy
+        MTEyMzEyMzEyMzIxMyJdLCJ0cmFja2luZ191cmwiOiJodHRwOlwvXC93ZWJ0
+        cmFjay5kaGxnbG9iYWxtYWlsLmNvbVwvP3RyYWNraW5nbnVtYmVyPTIxMTIz
+        MTIzMTIzMjEzIiwidHJhY2tpbmdfdXJscyI6WyJodHRwOlwvXC93ZWJ0cmFj
+        ay5kaGxnbG9iYWxtYWlsLmNvbVwvP3RyYWNraW5nbnVtYmVyPTIxMTIzMTIz
+        MTIzMjEzIl0sInJlY2VpcHQiOnt9LCJsaW5lX2l0ZW1zIjpbeyJpZCI6MTAw
+        NjkyOTA4MjAsInZhcmlhbnRfaWQiOjQyMDc3NDkyMTAwLCJ0aXRsZSI6IlBy
+        b2R1Y3Qgd2l0aCBzaW5nbGUgdmFyaWFudCIsInF1YW50aXR5IjoxLCJwcmlj
+        ZSI6IjAuMDAiLCJncmFtcyI6MCwic2t1IjoiIiwidmFyaWFudF90aXRsZSI6
+        Ik0iLCJ2ZW5kb3IiOiJTcHJlZSBTaG9waWZ5IEltcG9ydGVyIFRlc3QgU3Rv
+        cmUiLCJmdWxmaWxsbWVudF9zZXJ2aWNlIjoibWFudWFsIiwicHJvZHVjdF9p
+        ZCI6MTExMDE1MjU4MjgsInJlcXVpcmVzX3NoaXBwaW5nIjp0cnVlLCJ0YXhh
+        YmxlIjp0cnVlLCJnaWZ0X2NhcmQiOmZhbHNlLCJuYW1lIjoiUHJvZHVjdCB3
+        aXRoIHNpbmdsZSB2YXJpYW50IC0gTSIsInZhcmlhbnRfaW52ZW50b3J5X21h
+        bmFnZW1lbnQiOm51bGwsInByb3BlcnRpZXMiOltdLCJwcm9kdWN0X2V4aXN0
+        cyI6dHJ1ZSwiZnVsZmlsbGFibGVfcXVhbnRpdHkiOjIsInRvdGFsX2Rpc2Nv
+        dW50IjoiMC4wMCIsImZ1bGZpbGxtZW50X3N0YXR1cyI6InBhcnRpYWwiLCJ0
+        YXhfbGluZXMiOltdLCJvcmlnaW5fbG9jYXRpb24iOnsiaWQiOjMxMzI0OTkw
+        NzYsImNvdW50cnlfY29kZSI6IkhSIiwicHJvdmluY2VfY29kZSI6IiIsIm5h
+        bWUiOiJTcHJlZSBTaG9waWZ5IEltcG9ydGVyIFRlc3QgU3RvcmUiLCJhZGRy
+        ZXNzMSI6Ik9zamVja2EgNTgiLCJhZGRyZXNzMiI6IiIsImNpdHkiOiJTcGxp
+        dCIsInppcCI6IjIxMDAwIn0sImRlc3RpbmF0aW9uX2xvY2F0aW9uIjp7Imlk
+        IjozMTMyNTAwNDIwLCJjb3VudHJ5X2NvZGUiOiJQTCIsInByb3ZpbmNlX2Nv
+        ZGUiOiIiLCJuYW1lIjoiUGV0ZXIgUGFuIiwiYWRkcmVzczEiOiJTb21lIFN0
+        cmVldCIsImFkZHJlc3MyIjoiNSIsImNpdHkiOiJXYXJzemF3YSIsInppcCI6
+        IjAyLTc3NyJ9fV19LHsiaWQiOjQ0NTMyNTg3NTYsIm9yZGVyX2lkIjo1MTgy
+        NDM3MTI0LCJzdGF0dXMiOiJzdWNjZXNzIiwiY3JlYXRlZF9hdCI6IjIwMTct
+        MDYtMTVUMTc6NTM6NDQrMDI6MDAiLCJzZXJ2aWNlIjoibWFudWFsIiwidXBk
+        YXRlZF9hdCI6IjIwMTctMDYtMTVUMTc6NTM6NDUrMDI6MDAiLCJ0cmFja2lu
+        Z19jb21wYW55IjoiQ2FuYWRhIFBvc3QiLCJzaGlwbWVudF9zdGF0dXMiOm51
+        bGwsInRyYWNraW5nX251bWJlciI6IjExMjMyMTMxMjQxMjMyMTMiLCJ0cmFj
+        a2luZ19udW1iZXJzIjpbIjExMjMyMTMxMjQxMjMyMTMiXSwidHJhY2tpbmdf
+        dXJsIjoiaHR0cHM6XC9cL3d3dy5jYW5hZGFwb3N0LmNhXC9jcG90b29sc1wv
+        YXBwc1wvdHJhY2tcL3BlcnNvbmFsXC9maW5kQnlUcmFja051bWJlcj90cmFj
+        a2luZ051bWJlcj0xMTIzMjEzMTI0MTIzMjEzIiwidHJhY2tpbmdfdXJscyI6
+        WyJodHRwczpcL1wvd3d3LmNhbmFkYXBvc3QuY2FcL2Nwb3Rvb2xzXC9hcHBz
+        XC90cmFja1wvcGVyc29uYWxcL2ZpbmRCeVRyYWNrTnVtYmVyP3RyYWNraW5n
+        TnVtYmVyPTExMjMyMTMxMjQxMjMyMTMiXSwicmVjZWlwdCI6e30sImxpbmVf
+        aXRlbXMiOlt7ImlkIjoxMDA2OTI5MDc1NiwidmFyaWFudF9pZCI6NDE3MzMz
+        NDc1ODgsInRpdGxlIjoiTm8gdmFyaWFudHMiLCJxdWFudGl0eSI6MywicHJp
+        Y2UiOiIxNTAuMDAiLCJncmFtcyI6MCwic2t1IjoiIiwidmFyaWFudF90aXRs
+        ZSI6IiIsInZlbmRvciI6IlNwcmVlIFNob3BpZnkgSW1wb3J0ZXIgVGVzdCBT
+        dG9yZSIsImZ1bGZpbGxtZW50X3NlcnZpY2UiOiJtYW51YWwiLCJwcm9kdWN0
+        X2lkIjoxMTA1NTE2OTAyOCwicmVxdWlyZXNfc2hpcHBpbmciOnRydWUsInRh
+        eGFibGUiOnRydWUsImdpZnRfY2FyZCI6ZmFsc2UsIm5hbWUiOiJObyB2YXJp
+        YW50cyIsInZhcmlhbnRfaW52ZW50b3J5X21hbmFnZW1lbnQiOm51bGwsInBy
+        b3BlcnRpZXMiOltdLCJwcm9kdWN0X2V4aXN0cyI6dHJ1ZSwiZnVsZmlsbGFi
+        bGVfcXVhbnRpdHkiOjAsInRvdGFsX2Rpc2NvdW50IjoiMC4wMCIsImZ1bGZp
+        bGxtZW50X3N0YXR1cyI6ImZ1bGZpbGxlZCIsInRheF9saW5lcyI6W10sIm9y
+        aWdpbl9sb2NhdGlvbiI6eyJpZCI6MzEzMjQ5OTA3NiwiY291bnRyeV9jb2Rl
+        IjoiSFIiLCJwcm92aW5jZV9jb2RlIjoiIiwibmFtZSI6IlNwcmVlIFNob3Bp
+        ZnkgSW1wb3J0ZXIgVGVzdCBTdG9yZSIsImFkZHJlc3MxIjoiT3NqZWNrYSA1
+        OCIsImFkZHJlc3MyIjoiIiwiY2l0eSI6IlNwbGl0IiwiemlwIjoiMjEwMDAi
+        fSwiZGVzdGluYXRpb25fbG9jYXRpb24iOnsiaWQiOjMxMzI1MDA0MjAsImNv
+        dW50cnlfY29kZSI6IlBMIiwicHJvdmluY2VfY29kZSI6IiIsIm5hbWUiOiJQ
+        ZXRlciBQYW4iLCJhZGRyZXNzMSI6IlNvbWUgU3RyZWV0IiwiYWRkcmVzczIi
+        OiI1IiwiY2l0eSI6IldhcnN6YXdhIiwiemlwIjoiMDItNzc3In19LHsiaWQi
+        OjEwMDY5MjkwODIwLCJ2YXJpYW50X2lkIjo0MjA3NzQ5MjEwMCwidGl0bGUi
+        OiJQcm9kdWN0IHdpdGggc2luZ2xlIHZhcmlhbnQiLCJxdWFudGl0eSI6Miwi
+        cHJpY2UiOiIwLjAwIiwiZ3JhbXMiOjAsInNrdSI6IiIsInZhcmlhbnRfdGl0
+        bGUiOiJNIiwidmVuZG9yIjoiU3ByZWUgU2hvcGlmeSBJbXBvcnRlciBUZXN0
+        IFN0b3JlIiwiZnVsZmlsbG1lbnRfc2VydmljZSI6Im1hbnVhbCIsInByb2R1
+        Y3RfaWQiOjExMTAxNTI1ODI4LCJyZXF1aXJlc19zaGlwcGluZyI6dHJ1ZSwi
+        dGF4YWJsZSI6dHJ1ZSwiZ2lmdF9jYXJkIjpmYWxzZSwibmFtZSI6IlByb2R1
+        Y3Qgd2l0aCBzaW5nbGUgdmFyaWFudCAtIE0iLCJ2YXJpYW50X2ludmVudG9y
+        eV9tYW5hZ2VtZW50IjpudWxsLCJwcm9wZXJ0aWVzIjpbXSwicHJvZHVjdF9l
+        eGlzdHMiOnRydWUsImZ1bGZpbGxhYmxlX3F1YW50aXR5IjoyLCJ0b3RhbF9k
+        aXNjb3VudCI6IjAuMDAiLCJmdWxmaWxsbWVudF9zdGF0dXMiOiJwYXJ0aWFs
+        IiwidGF4X2xpbmVzIjpbXSwib3JpZ2luX2xvY2F0aW9uIjp7ImlkIjozMTMy
+        NDk5MDc2LCJjb3VudHJ5X2NvZGUiOiJIUiIsInByb3ZpbmNlX2NvZGUiOiIi
+        LCJuYW1lIjoiU3ByZWUgU2hvcGlmeSBJbXBvcnRlciBUZXN0IFN0b3JlIiwi
+        YWRkcmVzczEiOiJPc2plY2thIDU4IiwiYWRkcmVzczIiOiIiLCJjaXR5Ijoi
+        U3BsaXQiLCJ6aXAiOiIyMTAwMCJ9LCJkZXN0aW5hdGlvbl9sb2NhdGlvbiI6
+        eyJpZCI6MzEzMjUwMDQyMCwiY291bnRyeV9jb2RlIjoiUEwiLCJwcm92aW5j
+        ZV9jb2RlIjoiIiwibmFtZSI6IlBldGVyIFBhbiIsImFkZHJlc3MxIjoiU29t
+        ZSBTdHJlZXQiLCJhZGRyZXNzMiI6IjUiLCJjaXR5IjoiV2Fyc3phd2EiLCJ6
+        aXAiOiIwMi03NzcifX1dfV0sImNsaWVudF9kZXRhaWxzIjp7ImJyb3dzZXJf
+        aXAiOiI5NC43NS45Ni45OCIsImFjY2VwdF9sYW5ndWFnZSI6InBsLVBMLHBs
+        O3E9MC44LGVuLVVTO3E9MC42LGVuO3E9MC40IiwidXNlcl9hZ2VudCI6Ik1v
+        emlsbGFcLzUuMCAoTWFjaW50b3NoOyBJbnRlbCBNYWMgT1MgWCAxMF8xMl80
+        KSBBcHBsZVdlYktpdFwvNTM3LjM2IChLSFRNTCwgbGlrZSBHZWNrbykgQ2hy
+        b21lXC81OC4wLjMwMjkuMTEwIFNhZmFyaVwvNTM3LjM2Iiwic2Vzc2lvbl9o
+        YXNoIjpudWxsLCJicm93c2VyX3dpZHRoIjoxNDQwLCJicm93c2VyX2hlaWdo
+        dCI6ODI2fSwicmVmdW5kcyI6W10sInBheW1lbnRfZGV0YWlscyI6eyJjcmVk
+        aXRfY2FyZF9iaW4iOiIxIiwiYXZzX3Jlc3VsdF9jb2RlIjpudWxsLCJjdnZf
+        cmVzdWx0X2NvZGUiOm51bGwsImNyZWRpdF9jYXJkX251bWJlciI6IuKAouKA
+        ouKAouKAoiDigKLigKLigKLigKIg4oCi4oCi4oCi4oCiIDEiLCJjcmVkaXRf
+        Y2FyZF9jb21wYW55IjoiQm9ndXMifSwiY3VzdG9tZXIiOnsiaWQiOjU3MDE3
+        MzY4MzYsImVtYWlsIjoiYXJnb251c3Bpb3RyQGdtYWlsLmNvbSIsImFjY2Vw
+        dHNfbWFya2V0aW5nIjpmYWxzZSwiY3JlYXRlZF9hdCI6IjIwMTctMDYtMTVU
+        MTc6NTE6NDcrMDI6MDAiLCJ1cGRhdGVkX2F0IjoiMjAxNy0wNi0xNVQxNzo1
+        MjoyOSswMjowMCIsImZpcnN0X25hbWUiOiJQZXRlciIsImxhc3RfbmFtZSI6
+        IlBhbiIsIm9yZGVyc19jb3VudCI6MCwic3RhdGUiOiJkaXNhYmxlZCIsInRv
+        dGFsX3NwZW50IjoiMC4wMCIsImxhc3Rfb3JkZXJfaWQiOm51bGwsIm5vdGUi
+        Om51bGwsInZlcmlmaWVkX2VtYWlsIjp0cnVlLCJtdWx0aXBhc3NfaWRlbnRp
+        ZmllciI6bnVsbCwidGF4X2V4ZW1wdCI6ZmFsc2UsInBob25lIjpudWxsLCJ0
+        YWdzIjoiIiwibGFzdF9vcmRlcl9uYW1lIjpudWxsLCJkZWZhdWx0X2FkZHJl
+        c3MiOnsiaWQiOjU5ODU1MDIyMTIsImZpcnN0X25hbWUiOiJQZXRlciIsImxh
+        c3RfbmFtZSI6IlBhbiIsImNvbXBhbnkiOm51bGwsImFkZHJlc3MxIjoiU29t
+        ZSBTdHJlZXQiLCJhZGRyZXNzMiI6IjUiLCJjaXR5IjoiV2Fyc3phd2EiLCJw
+        cm92aW5jZSI6bnVsbCwiY291bnRyeSI6IlBvbGFuZCIsInppcCI6IjAyLTc3
+        NyIsInBob25lIjpudWxsLCJuYW1lIjoiUGV0ZXIgUGFuIiwicHJvdmluY2Vf
+        Y29kZSI6bnVsbCwiY291bnRyeV9jb2RlIjoiUEwiLCJjb3VudHJ5X25hbWUi
+        OiJQb2xhbmQiLCJkZWZhdWx0Ijp0cnVlfX19XX0=
+    http_version: 
+  recorded_at: Sat, 17 Jun 2017 14:37:51 GMT
+- request:
+    method: get
+    uri: https://spree-shopify-importer-test-store.myshopify.com/admin/orders.json?page=2
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Basic MGE5NDQ1YjdiMDY3NzE5YTBhZjAyNDYxMDM2NGVlMzQ6ODAwZjk3ZDZlYTFhNzY4MDQ4ODUxY2RkOTlhOTEwMWE=
+      Accept:
+      - application/json
+      User-Agent:
+      - ShopifyAPI/4.9.0 ActiveResource/5.0.0 Ruby/2.3.4
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Sat, 17 Jun 2017 14:37:39 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Sorting-Hat-Podid:
+      - '3'
+      X-Sorting-Hat-Podid-Cached:
+      - '0'
+      X-Sorting-Hat-Shopid:
+      - '20513691'
+      X-Sorting-Hat-Section:
+      - pod
+      X-Sorting-Hat-Shopid-Cached:
+      - '0'
+      Vary:
+      - Accept-Encoding
+      Referrer-Policy:
+      - origin-when-cross-origin
+      X-Frame-Options:
+      - DENY
+      X-Shopid:
+      - '20513691'
+      X-Shardid:
+      - '3'
+      X-Shopify-Shop-Api-Call-Limit:
+      - 1/40
+      Http-X-Shopify-Shop-Api-Call-Limit:
+      - 1/40
+      X-Stats-Userid:
+      - '0'
+      X-Stats-Apiclientid:
+      - '1680429'
+      X-Stats-Apipermissionid:
+      - '52824317'
+      X-Request-Id:
+      - 9dcaf99a-a12a-444b-9680-be09ef869be5
+      Content-Security-Policy:
+      - 'default-src ''self'' data: blob: ''unsafe-inline'' ''unsafe-eval'' https://*
+        shopify-pos://*; block-all-mixed-content; child-src ''self'' https://* shopify-pos://*;
+        connect-src ''self'' wss://* https://*; script-src https://cdn.shopify.com
+        https://checkout.shopifycs.com https://js-agent.newrelic.com https://bam.nr-data.net
+        https://dme0ih8comzn4.cloudfront.net https://api.stripe.com https://mpsnare.iesnare.com
+        https://appcenter.intuit.com https://www.paypal.com https://maps.googleapis.com
+        https://stats.g.doubleclick.net https://www.google-analytics.com https://visitors.shopify.com
+        https://v.shopify.com https://widget.intercom.io https://js.intercomcdn.com
+        ''self'' ''unsafe-inline'' ''unsafe-eval''; upgrade-insecure-requests; report-uri
+        /csp-report?source%5Baction%5D=index&source%5Bapp%5D=Shopify&source%5Bcontroller%5D=admin%2Forders&source%5Bsection%5D=admin&source%5Buuid%5D=9dcaf99a-a12a-444b-9680-be09ef869be5'
+      X-Content-Type-Options:
+      - nosniff
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Xss-Protection:
+      - 1; mode=block; report=/xss-report?source%5Baction%5D=index&source%5Bapp%5D=Shopify&source%5Bcontroller%5D=admin%2Forders&source%5Bsection%5D=admin&source%5Buuid%5D=9dcaf99a-a12a-444b-9680-be09ef869be5
+      P3p:
+      - CP="NOI DSP COR NID ADMa OPTa OUR NOR"
+      X-Dc:
+      - ash
+    body:
+      encoding: ASCII-8BIT
+      string: '{"orders":[]}'
+    http_version: 
+  recorded_at: Sat, 17 Jun 2017 14:37:52 GMT
+recorded_with: VCR 3.0.3

--- a/spec/vcr/shopify/order/count.yml
+++ b/spec/vcr/shopify/order/count.yml
@@ -1,0 +1,94 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://spree-shopify-importer-test-store.myshopify.com/admin/orders/count.json
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Basic MGE5NDQ1YjdiMDY3NzE5YTBhZjAyNDYxMDM2NGVlMzQ6ODAwZjk3ZDZlYTFhNzY4MDQ4ODUxY2RkOTlhOTEwMWE=
+      Accept:
+      - application/json
+      User-Agent:
+      - ShopifyAPI/4.9.0 ActiveResource/5.0.0 Ruby/2.3.4
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Sat, 17 Jun 2017 14:37:38 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Sorting-Hat-Podid:
+      - '3'
+      X-Sorting-Hat-Podid-Cached:
+      - '0'
+      X-Sorting-Hat-Shopid:
+      - '20513691'
+      X-Sorting-Hat-Section:
+      - pod
+      X-Sorting-Hat-Shopid-Cached:
+      - '0'
+      Vary:
+      - Accept-Encoding
+      Referrer-Policy:
+      - origin-when-cross-origin
+      X-Frame-Options:
+      - DENY
+      X-Shopid:
+      - '20513691'
+      X-Shardid:
+      - '3'
+      X-Shopify-Shop-Api-Call-Limit:
+      - 1/40
+      Http-X-Shopify-Shop-Api-Call-Limit:
+      - 1/40
+      X-Stats-Userid:
+      - '0'
+      X-Stats-Apiclientid:
+      - '1680429'
+      X-Stats-Apipermissionid:
+      - '52824317'
+      X-Request-Id:
+      - f159f18e-3f24-4a34-8374-25d6f378bd96
+      Content-Security-Policy:
+      - 'default-src ''self'' data: blob: ''unsafe-inline'' ''unsafe-eval'' https://*
+        shopify-pos://*; block-all-mixed-content; child-src ''self'' https://* shopify-pos://*;
+        connect-src ''self'' wss://* https://*; script-src https://cdn.shopify.com
+        https://checkout.shopifycs.com https://js-agent.newrelic.com https://bam.nr-data.net
+        https://dme0ih8comzn4.cloudfront.net https://api.stripe.com https://mpsnare.iesnare.com
+        https://appcenter.intuit.com https://www.paypal.com https://maps.googleapis.com
+        https://stats.g.doubleclick.net https://www.google-analytics.com https://visitors.shopify.com
+        https://v.shopify.com https://widget.intercom.io https://js.intercomcdn.com
+        ''self'' ''unsafe-inline'' ''unsafe-eval''; upgrade-insecure-requests; report-uri
+        /csp-report?source%5Baction%5D=count&source%5Bapp%5D=Shopify&source%5Bcontroller%5D=admin%2Forders&source%5Bsection%5D=admin&source%5Buuid%5D=f159f18e-3f24-4a34-8374-25d6f378bd96'
+      X-Content-Type-Options:
+      - nosniff
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Xss-Protection:
+      - 1; mode=block; report=/xss-report?source%5Baction%5D=count&source%5Bapp%5D=Shopify&source%5Bcontroller%5D=admin%2Forders&source%5Bsection%5D=admin&source%5Buuid%5D=f159f18e-3f24-4a34-8374-25d6f378bd96
+      P3p:
+      - CP="NOI DSP COR NID ADMa OPTa OUR NOR"
+      X-Dc:
+      - ash
+    body:
+      encoding: ASCII-8BIT
+      string: '{"count":1}'
+    http_version: 
+  recorded_at: Sat, 17 Jun 2017 14:37:50 GMT
+recorded_with: VCR 3.0.3


### PR DESCRIPTION
- Add base Shopify order model
- Add base data parser for Shopify order. There are only basic order attributes, without associations like line items, shipments, and payments.
- Add base order creator. The order is created without shipments, line items, payments, refunds etc. They will be added in next PR.  
- Add skip model validation as Order Import logic will need it for line items/payments etc. 