### PR TITLE
Add parent/children association in shopify data feed

### DIFF
--- a/app/models/shopify/data_feed.rb
+++ b/app/models/shopify/data_feed.rb
@@ -1,6 +1,8 @@
 module Shopify
   class DataFeed < ApplicationRecord
     belongs_to :spree_object, polymorphic: true
+    belongs_to :parent, class_name: 'Shopify::DataFeed'
+    has_many :children, class_name: 'Shopify::DataFeed', foreign_key: :parent_id
 
     validates :shopify_object_id, :shopify_object_type, presence: true
     validates :shopify_object_id, uniqueness: { scope: :shopify_object_type }

--- a/app/services/shopify/data_feeds/create.rb
+++ b/app/services/shopify/data_feeds/create.rb
@@ -3,15 +3,17 @@ module Shopify
     class Create
       attr_reader :shopify_object
 
-      def initialize(shopify_object)
+      def initialize(shopify_object, parent = nil)
         @shopify_object = shopify_object
+        @parent = parent
       end
 
       def save!
         Shopify::DataFeed.create!(
           shopify_object_id: shopify_object.id,
           shopify_object_type: shopify_type,
-          data_feed: shopify_object.to_json
+          data_feed: shopify_object.to_json,
+          parent: @parent
         )
       end
 

--- a/app/services/shopify_import/creators/product.rb
+++ b/app/services/shopify_import/creators/product.rb
@@ -54,7 +54,8 @@ module ShopifyImport
 
       def create_spree_variants
         @shopify_product.variants.each do |variant|
-          ShopifyImport::Creators::Variant.new(variant, @spree_product).save!
+          data_feed = Shopify::DataFeeds::Create.new(variant, @shopify_data_feed).save!
+          ShopifyImport::Creators::Variant.new(data_feed, @spree_product).save!
         end
       end
 

--- a/app/services/shopify_import/creators/variant.rb
+++ b/app/services/shopify_import/creators/variant.rb
@@ -1,8 +1,8 @@
 module ShopifyImport
   module Creators
-    class Variant
-      def initialize(shopify_variant, spree_product)
-        @shopify_variant = shopify_variant
+    class Variant < ShopifyImport::Creators::Base
+      def initialize(shopify_data_feed, spree_product)
+        super(shopify_data_feed)
         @spree_product = spree_product
       end
 
@@ -49,7 +49,11 @@ module ShopifyImport
       end
 
       def parser
-        @parser ||= ShopifyImport::DataParsers::Variants::BaseData.new(@shopify_variant, @spree_product)
+        @parser ||= ShopifyImport::DataParsers::Variants::BaseData.new(shopify_variant, @spree_product)
+      end
+
+      def shopify_variant
+        ShopifyAPI::Variant.new(data_feed)
       end
     end
   end

--- a/db/migrate/20170625115401_add_parent_id_to_shopify_data_feed.rb
+++ b/db/migrate/20170625115401_add_parent_id_to_shopify_data_feed.rb
@@ -1,0 +1,6 @@
+class AddParentIdToShopifyDataFeed < ActiveRecord::Migration[5.0]
+  def change
+    add_column :shopify_data_feeds, :parent_id, :integer
+    add_index :shopify_data_feeds, :parent_id
+  end
+end

--- a/spec/models/shopify/data_feed_spec.rb
+++ b/spec/models/shopify/data_feed_spec.rb
@@ -4,6 +4,7 @@ RSpec.describe Shopify::DataFeed, type: :model do
   describe 'database' do
     it { is_expected.to have_db_index([:shopify_object_id, :shopify_object_type]).unique }
     it { is_expected.to have_db_index([:spree_object_id, :spree_object_type]).unique }
+    it { is_expected.to have_db_index(:parent_id) }
   end
 
   describe 'validations' do
@@ -20,5 +21,7 @@ RSpec.describe Shopify::DataFeed, type: :model do
 
   describe 'associations' do
     it { is_expected.to belong_to(:spree_object) }
+    it { is_expected.to belong_to(:parent).class_name('Shopify::DataFeed') }
+    it { is_expected.to have_many(:children).class_name('Shopify::DataFeed').with_foreign_key(:parent_id) }
   end
 end

--- a/spec/services/shopify/data_feeds/create_spec.rb
+++ b/spec/services/shopify/data_feeds/create_spec.rb
@@ -25,6 +25,20 @@ RSpec.describe Shopify::DataFeeds::Create, type: :service do
         it 'shopify object as data feed' do
           expect(data_feed.data_feed).to eq shopify_object.to_json.to_s
         end
+
+        it 'does not assigns parent' do
+          expect(data_feed.parent).to be_nil
+        end
+
+        context 'with existing parent' do
+          let!(:parent) { create(:shopify_data_feed) }
+
+          subject { described_class.new(shopify_object, parent) }
+
+          it 'assigns parent to data feed' do
+            expect(data_feed.parent).to eq parent
+          end
+        end
       end
     end
   end

--- a/spec/services/shopify_import/creators/product_spec.rb
+++ b/spec/services/shopify_import/creators/product_spec.rb
@@ -70,6 +70,14 @@ RSpec.describe ShopifyImport::Creators::Product, type: :service do
         end
       end
 
+      context 'shopify data feeds for variants' do
+        it 'creates data feeds' do
+          expect { subject.save! }.to change {
+            Shopify::DataFeed.where(shopify_object_type: 'ShopifyAPI::Variant').reload.count
+          }.by(1)
+        end
+      end
+
       context 'option types' do
         let(:spree_product) { Spree::Product.find_by!(slug: shopify_product.handle) }
         let(:shopify_product) do

--- a/spec/services/shopify_import/creators/variant_spec.rb
+++ b/spec/services/shopify_import/creators/variant_spec.rb
@@ -4,6 +4,12 @@ RSpec.describe ShopifyImport::Creators::Variant, type: :service do
   let(:spree_product) { create(:product) }
   let(:shopify_variant) { create(:shopify_variant, sku: '1234') }
   let(:option_type) { create(:option_type) }
+  let(:shopify_data_feed) do
+    create(:shopify_data_feed,
+           shopify_object_type: 'ShopifyAPI::Variant',
+           shopify_object_id: shopify_variant.id,
+           data_feed: shopify_variant.to_json)
+  end
   let!(:f_option_value) do
     create(:option_value, name: shopify_variant.option1.strip.downcase, option_type: option_type)
   end
@@ -14,7 +20,7 @@ RSpec.describe ShopifyImport::Creators::Variant, type: :service do
     create(:option_value, name: shopify_variant.option3.strip.downcase, option_type: option_type)
   end
 
-  subject { described_class.new(shopify_variant, spree_product) }
+  subject { described_class.new(shopify_data_feed, spree_product) }
 
   before { spree_product.option_types << option_type }
 

--- a/spec/services/shopify_import/importers/products_importer_spec.rb
+++ b/spec/services/shopify_import/importers/products_importer_spec.rb
@@ -8,21 +8,29 @@ RSpec.describe ShopifyImport::Importers::ProductsImporter, type: :service do
       let(:params) { { created_at_min: '2017-06-04T15:00:00+02:00' } }
 
       it 'creates shopify data feeds' do
-        expect { described_class.new(params).import! }.to change(Shopify::DataFeed, :count).by(1)
+        expect { described_class.new(params).import! }.to change(Shopify::DataFeed, :count).by(2)
       end
 
       it 'creates spree products' do
         expect { described_class.new(params).import! }.to change(Spree::Product, :count).by(1)
       end
+
+      it 'creates spree variants' do
+        expect { described_class.new(params).import! }.to change(Spree::Variant, :count).by(2)
+      end
     end
 
     context 'without params', vcr: { cassette_name: 'shopify_import/products_importer/import' } do
       it 'creates shopify data feeds' do
-        expect { described_class.new.import! }.to change(Shopify::DataFeed, :count).by(2)
+        expect { described_class.new.import! }.to change(Shopify::DataFeed, :count).by(4)
       end
 
       it 'creates spree products' do
         expect { described_class.new.import! }.to change(Spree::Product, :count).by(2)
+      end
+
+      it 'creates spree variants' do
+        expect { described_class.new.import! }.to change(Spree::Variant, :count).by(4)
       end
     end
   end


### PR DESCRIPTION
- Add parent/children association in Shopify data feed. It will be used in the creation of objects wich are not included main Shopify JSON response like transactions for orders. 