### PR TITLE
Feature/order address integration

### DIFF
--- a/app/services/shopify_import/data_parsers/addresses/base_data.rb
+++ b/app/services/shopify_import/data_parsers/addresses/base_data.rb
@@ -2,13 +2,12 @@ module ShopifyImport
   module DataParsers
     module Addresses
       class BaseData
-        def initialize(shopify_address, spree_user)
+        def initialize(shopify_address)
           @shopify_address = shopify_address
-          @spree_user = spree_user
         end
 
         # rubocop:disable Metrics/MethodLength
-        def address_attributes
+        def attributes
           {
             firstname: @shopify_address.first_name,
             lastname: @shopify_address.last_name,
@@ -19,8 +18,7 @@ module ShopifyImport
             city: @shopify_address.city,
             zipcode: @shopify_address.zip,
             state: state,
-            country: country,
-            user_id: @spree_user.id
+            country: country
           }
         end
         # rubocop:enable Metrics/MethodLength
@@ -29,7 +27,7 @@ module ShopifyImport
 
         def country
           @country ||= Spree::Country.find_or_create_by!(iso: @shopify_address.country_code) do |country|
-            country.name = @shopify_address.country_name
+            country.name = @shopify_address.try(:country_name) || @shopify_address.try(:country)
             country.iso_name = country.name.upcase
           end
         end

--- a/app/services/shopify_import/importers/address_importer.rb
+++ b/app/services/shopify_import/importers/address_importer.rb
@@ -8,7 +8,7 @@ module ShopifyImport
 
       def import!
         data_feed = create_data_feed
-        ShopifyImport::Creators::AddressCreator.new(data_feed, @spree_user).save!
+        ShopifyImport::Creators::AddressCreator.new(data_feed, @spree_user).create!
       end
 
       private

--- a/spec/features/integration_spec.rb
+++ b/spec/features/integration_spec.rb
@@ -23,5 +23,6 @@ RSpec.feature 'end to end import' do
     expect(Spree::Shipment.count).to eq 3
     expect(Spree::ShippingRate.count).to eq 3
     expect(Spree::InventoryUnit.count).to eq 8
+    expect(Spree::Address.count).to eq 5
   end
 end

--- a/spec/services/shopify_import/creators/address_creator_spec.rb
+++ b/spec/services/shopify_import/creators/address_creator_spec.rb
@@ -17,13 +17,13 @@ RSpec.describe ShopifyImport::Creators::AddressCreator do
     let(:spree_user) { create(:user) }
 
     it 'creates spree address' do
-      expect { subject.save! }.to change(Spree::Address, :count).by(1)
+      expect { subject.create! }.to change(Spree::Address, :count).by(1)
     end
 
     context 'sets address attributes' do
       let(:spree_address) { Spree::Address.last }
 
-      before { subject.save! }
+      before { subject.create! }
 
       it 'firstname' do
         expect(spree_address.firstname).to eq shopify_address.first_name
@@ -64,23 +64,23 @@ RSpec.describe ShopifyImport::Creators::AddressCreator do
       let(:address) { Spree::Address.last }
 
       it 'assigns new address to user' do
-        expect { subject.save! }.to change { spree_user.addresses.reload.count }.by(1)
+        expect { subject.create! }.to change { spree_user.addresses.reload.count }.by(1)
       end
 
       it 'assigns country to address' do
-        subject.save!
+        subject.create!
 
         expect(address.country).to eq country
       end
 
       it 'assigns state to address' do
-        subject.save!
+        subject.create!
 
         expect(address.state).to eq state
       end
 
       it 'assigns spree address to shopify data feed' do
-        subject.save!
+        subject.create!
 
         expect(shopify_data_feed.reload.spree_object).to eq address
       end

--- a/spec/services/shopify_import/data_parsers/addresses/base_data_spec.rb
+++ b/spec/services/shopify_import/data_parsers/addresses/base_data_spec.rb
@@ -4,7 +4,7 @@ describe ShopifyImport::DataParsers::Addresses::BaseData, type: :service do
   let(:spree_user) { create(:user) }
   let(:shopify_address) { create(:shopify_address) }
 
-  subject { described_class.new(shopify_address, spree_user) }
+  subject { described_class.new(shopify_address) }
 
   describe '#address_attributes' do
     let(:state) { Spree::State.find_by!(abbr: shopify_address.province_code) }
@@ -20,20 +20,19 @@ describe ShopifyImport::DataParsers::Addresses::BaseData, type: :service do
         city: shopify_address.city,
         zipcode: shopify_address.zip,
         state: state,
-        country: country,
-        user_id: spree_user.id
+        country: country
       }
     end
 
     it 'returns hash of address attributes' do
-      expect(subject.address_attributes).to eq result
+      expect(subject.attributes).to eq result
     end
 
     context 'when there is no country' do
       let(:shopify_address) { create(:shopify_address, country_code: 'NONEXISTING') }
 
       it 'creates a country' do
-        expect { subject.address_attributes }.to change(Spree::Country, :count).by(1)
+        expect { subject.attributes }.to change(Spree::Country, :count).by(1)
       end
     end
 
@@ -41,7 +40,7 @@ describe ShopifyImport::DataParsers::Addresses::BaseData, type: :service do
       let(:shopify_address) { create(:shopify_address, province_code: 'NONEXISTING') }
 
       it 'creates a country' do
-        expect { subject.address_attributes }.to change(Spree::State, :count).by(1)
+        expect { subject.attributes }.to change(Spree::State, :count).by(1)
       end
     end
   end

--- a/spec/services/shopify_import/importers/order_importer_spec.rb
+++ b/spec/services/shopify_import/importers/order_importer_spec.rb
@@ -6,7 +6,15 @@ describe ShopifyImport::Importers::OrderImporter, type: :service do
   before { authenticate_with_shopify }
 
   describe '#import!', vcr: { cassette_name: 'shopify_import/importers/order_importer' } do
-    let(:resource) { ShopifyAPI::Order.find(5_182_437_124).to_json }
+    let!(:shopify_order) { ShopifyAPI::Order.find(5_182_437_124) }
+    let!(:user) { create(:user) }
+    let!(:user_data_feed) do
+      create(:shopify_data_feed,
+             spree_object: user,
+             shopify_object_id: shopify_order.customer.id,
+             shopify_object_type: 'ShopifyAPI::Customer')
+    end
+    let(:resource) { shopify_order.to_json }
 
     it 'creates shopify data feeds' do
       expect { subject.import! }.to change(Shopify::DataFeed, :count).by(5)


### PR DESCRIPTION
- Add integration between order and address import
- Order addresses in Shopify do not have ID, so I am not saving data feed for now