### PR TITLE
Improve code by rubocop RSpec/LetSetup rule, get rid of let!

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -12,6 +12,7 @@ AllCops:
 require:
   - rubocop-rails
   - rubocop-rspec
+  - ./lib/rubocop/rspec/let_bang
 Metrics/AbcSize:
   Exclude:
     - 'db/migrate/**'
@@ -63,5 +64,5 @@ Style/DateTime:
   Enabled: false
 Style/Documentation:
   Enabled: false
-RSpec/LetSetup:
-  Enabled: false
+RSpec/LetBang:
+  Enabled: true

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,6 +2,7 @@ inherit_from: .rubocop_todo.yml
 
 AllCops:
   DisplayCopNames: true
+  DisabledByDefault: true
   Exclude:
    - 'bin/*'
    - 'db/**/*'
@@ -10,12 +11,13 @@ AllCops:
    - 'gemfiles/*'
 require:
   - rubocop-rails
+  - rubocop-rspec
 Metrics/AbcSize:
   Exclude:
     - 'db/migrate/**'
 Metrics/BlockLength:
   Exclude:
-    - config/environments/production.rb
+    - 'config/environments/production.rb'
     - '**/*_spec.rb'
     - 'spec/support/shared_examples/**'
     - '**/factories/**/*'
@@ -60,4 +62,6 @@ Style/SymbolArray:
 Style/DateTime:
   Enabled: false
 Style/Documentation:
+  Enabled: false
+RSpec/LetSetup:
   Enabled: false

--- a/app/services/spree_shopify_importer/data_parsers/inventory_units/base_data.rb
+++ b/app/services/spree_shopify_importer/data_parsers/inventory_units/base_data.rb
@@ -34,10 +34,9 @@ module SpreeShopifyImporter
         end
 
         def inventory_unit_state
-          case @spree_shipment.state.to_sym
-          when :shipped then :shipped
-          else :on_hand
-          end
+          return :shipped if @spree_shipment.state.to_sym == :shipped
+
+          :on_hand
         end
 
         def shopify_variant_id

--- a/app/services/spree_shopify_importer/data_parsers/orders/base_data.rb
+++ b/app/services/spree_shopify_importer/data_parsers/orders/base_data.rb
@@ -87,7 +87,7 @@ module SpreeShopifyImporter
         end
 
         def shipment_total
-          @shopify_order.shipping_lines.sum { |sl| sl.price.to_d }
+          @shopify_order.shipping_lines.sum { |shipping_line| shipping_line.price.to_d }
         end
 
         def states_getter

--- a/app/services/spree_shopify_importer/data_parsers/products/base_data.rb
+++ b/app/services/spree_shopify_importer/data_parsers/products/base_data.rb
@@ -31,10 +31,6 @@ module SpreeShopifyImporter
         def shipping_category
           Spree::ShippingCategory.find_or_create_by!(name: I18n.t(:shopify))
         end
-
-        def option_values(values)
-          values.map(&:strip)
-        end
       end
     end
   end

--- a/app/services/spree_shopify_importer/data_savers/addresses/address_updater.rb
+++ b/app/services/spree_shopify_importer/data_savers/addresses/address_updater.rb
@@ -8,9 +8,7 @@ module SpreeShopifyImporter
         end
 
         def update!
-          Spree::Address.transaction do
-            update_spree_address
-          end
+          update_spree_address
 
           @spree_address
         end

--- a/app/services/spree_shopify_importer/data_savers/images/image_base.rb
+++ b/app/services/spree_shopify_importer/data_savers/images/image_base.rb
@@ -19,11 +19,7 @@ module SpreeShopifyImporter
         end
 
         def attributes_with_attachement
-          if Spree.version.to_f < 4.0
-            attributes.merge(attachment: attachment)
-          else
-            attributes.merge(attachment_content_type: attachment)
-          end
+          attributes.merge(attachment_content_type: attachment)
         end
 
         def shopify_image

--- a/app/services/spree_shopify_importer/data_savers/images/image_creator.rb
+++ b/app/services/spree_shopify_importer/data_savers/images/image_creator.rb
@@ -8,33 +8,30 @@ module SpreeShopifyImporter
         end
 
         def create!
-          Spree::Image.transaction do
-            return unless valid_path?
-            return if @spree_object.images.pluck(:attachment_file_name).include?(name)
+          return unless valid_path?
+          return if @spree_object.images.pluck(:attachment_file_name).include?(name)
 
+          Spree::Image.transaction do
             create_spree_image
             assign_spree_image_to_data_feed
           end
+
           update_timestamps
+          @spree_image
         end
 
         private
 
         def create_spree_image
-          # Needs to be corrected for spree > 4.0
-          if Spree.version.to_f < 4.0
-            @spree_image = @spree_object.images.create!(attributes_with_attachement)
-          else
-            @spree_image = Spree::Image.new(attributes_with_attachement)
-            @spree_image.attachment.attach(
-                io: File.new(attributes_with_attachement[:attachment_content_type]),
-                filename: attributes_with_attachement[:alt],
-                content_type: attributes_with_attachement[:attachment_content_type]
-              ).save.save
-            @spree_image.save
-            @spree_object.images << @spree_image
-            @spree_image
-          end
+          # TODO: Needs to be corrected for spree > 4.0
+          @spree_image = Spree::Image.new(attributes_with_attachement)
+          @spree_image.attachment.attach(
+              io: File.new(attributes_with_attachement[:attachment_content_type]),
+              filename: attributes_with_attachement[:alt],
+              content_type: attributes_with_attachement[:attachment_content_type]
+            ).save.save
+          @spree_image.save!
+          @spree_object.images << @spree_image
         end
       end
     end

--- a/app/services/spree_shopify_importer/data_savers/images/image_updater.rb
+++ b/app/services/spree_shopify_importer/data_savers/images/image_updater.rb
@@ -2,10 +2,9 @@ module SpreeShopifyImporter
   module DataSavers
     module Images
       class ImageUpdater < ImageBase
-        def initialize(shopify_data_feed, spree_image, spree_object)
+        def initialize(shopify_data_feed, spree_image)
           super(shopify_data_feed)
           @spree_image = spree_image
-          @spree_object = spree_object # can be product or variant
         end
 
         def update!

--- a/app/services/spree_shopify_importer/data_savers/line_items/line_item_creator.rb
+++ b/app/services/spree_shopify_importer/data_savers/line_items/line_item_creator.rb
@@ -12,16 +12,12 @@ module SpreeShopifyImporter
           return if spree_variant.blank?
 
           line_item = @spree_order.line_items.find_or_initialize_by(variant: spree_variant)
-          line_item.assign_attributes(line_item_attributes)
+          line_item.assign_attributes(parser.line_item_attributes)
           line_item.save(validate: false)
           line_item
         end
 
         private
-
-        def line_item_attributes
-          parser.line_item_attributes
-        end
 
         def spree_variant
           parser.variant

--- a/app/services/spree_shopify_importer/data_savers/option_values/option_value_creator.rb
+++ b/app/services/spree_shopify_importer/data_savers/option_values/option_value_creator.rb
@@ -10,12 +10,10 @@ module SpreeShopifyImporter
         end
 
         def create!
-          Spree::OptionValue.transaction do
-            Spree::OptionValue
-              .where(option_type: @spree_option_type)
-              .where('lower(name) = ?', name)
-              .first_or_create!(attributes)
-          end
+          Spree::OptionValue
+            .where(option_type: @spree_option_type)
+            .where('lower(name) = ?', name)
+            .first_or_create!(attributes)
         end
 
         private

--- a/app/services/spree_shopify_importer/data_savers/refunds/refund_creator.rb
+++ b/app/services/spree_shopify_importer/data_savers/refunds/refund_creator.rb
@@ -27,10 +27,8 @@ module SpreeShopifyImporter
         end
 
         def create_refund
-          Spree::Refund.transaction do
-            @spree_refund = Spree::Refund.find_or_initialize_by(transaction_id: transaction_id)
-            update_spree_refund
-          end
+          @spree_refund = Spree::Refund.find_or_initialize_by(transaction_id: transaction_id)
+          update_spree_refund
         end
 
         def update_spree_refund

--- a/app/services/spree_shopify_importer/data_savers/return_authorizations/return_authorization_creator.rb
+++ b/app/services/spree_shopify_importer/data_savers/return_authorizations/return_authorization_creator.rb
@@ -10,11 +10,9 @@ module SpreeShopifyImporter
         end
 
         def create
-          Spree::ReturnAuthorization.transaction do
-            @spree_return_authorization = @spree_order.return_authorizations.find_or_initialize_by(number: number)
-            update_attributes
-            assign_spree_order_to_data_feed
-          end
+          @spree_return_authorization = @spree_order.return_authorizations.find_or_initialize_by(number: number)
+          update_attributes
+          assign_spree_order_to_data_feed
           update_timestamps
           @spree_return_authorization
         end

--- a/app/services/spree_shopify_importer/data_savers/users/user_base.rb
+++ b/app/services/spree_shopify_importer/data_savers/users/user_base.rb
@@ -23,7 +23,9 @@ module SpreeShopifyImporter
         end
 
         def create_spree_addresses
-          return if (addresses = shopify_customer.try(:addresses)).blank?
+          addresses = shopify_customer.try(:addresses)
+
+          return if addresses.blank?
 
           addresses.each do |address|
             SpreeShopifyImporter::Importers::AddressImporterJob.perform_later(address.to_json, @spree_user)

--- a/app/services/spree_shopify_importer/data_savers/users/user_updater.rb
+++ b/app/services/spree_shopify_importer/data_savers/users/user_updater.rb
@@ -11,8 +11,8 @@ module SpreeShopifyImporter
           Spree.user_class.transaction do
             update_spree_user
             generate_api_key
-            create_spree_addresses
           end
+          create_spree_addresses
         end
 
         private

--- a/app/services/spree_shopify_importer/data_savers/variants/variant_creator.rb
+++ b/app/services/spree_shopify_importer/data_savers/variants/variant_creator.rb
@@ -9,12 +9,10 @@ module SpreeShopifyImporter
         end
 
         def create!
-          Spree::Variant.transaction do
-            @spree_variant = build_spree_variant
-            add_option_values
-            @spree_variant.save!
-            assign_spree_variant_to_data_feed
-          end
+          @spree_variant = build_spree_variant
+          add_option_values
+          @spree_variant.save!
+          assign_spree_variant_to_data_feed
           create_spree_image if @shopify_image.present?
         end
 

--- a/app/services/spree_shopify_importer/data_savers/zones/zone_creator.rb
+++ b/app/services/spree_shopify_importer/data_savers/zones/zone_creator.rb
@@ -30,7 +30,7 @@ module SpreeShopifyImporter
         end
 
         def create_spree_zone
-          Spree::Zone.create(attributes)
+          Spree::Zone.create!(attributes)
         end
 
         def parent_feed

--- a/app/services/spree_shopify_importer/importers/image_importer.rb
+++ b/app/services/spree_shopify_importer/importers/image_importer.rb
@@ -1,8 +1,8 @@
 module SpreeShopifyImporter
   module Importers
     class ImageImporter < BaseImporter
-      def initialize(resourece, parent_feed, spree_viewable)
-        @resource = resourece
+      def initialize(resource, parent_feed, spree_viewable)
+        @resource = resource
         @parent_feed = parent_feed
         @spree_viewable = spree_viewable
       end
@@ -13,7 +13,7 @@ module SpreeShopifyImporter
         if (spree_object = data_feed.spree_object).blank?
           creator.new(data_feed, @spree_viewable).create!
         else
-          updater.new(data_feed, spree_object, @spree_viewable).update!
+          updater.new(data_feed, spree_object).update!
         end
       end
 

--- a/app/services/spree_shopify_importer/importers/order_importer.rb
+++ b/app/services/spree_shopify_importer/importers/order_importer.rb
@@ -19,7 +19,9 @@ module SpreeShopifyImporter
       end
 
       def clear_order_data(data_feed)
-        return if (order = data_feed.spree_object).blank?
+        order = data_feed.spree_object
+
+        return if order.blank?
 
         order.bill_address.delete
         order.ship_address.delete

--- a/app/services/spree_shopify_importer/importers/user_importer.rb
+++ b/app/services/spree_shopify_importer/importers/user_importer.rb
@@ -3,6 +3,7 @@ module SpreeShopifyImporter
     class UserImporter < BaseImporter
       def import!
         data_feed = process_data_feed
+
         return if shopify_object.email.blank?
 
         if (spree_object = data_feed.spree_object).blank?

--- a/lib/rubocop/rspec/let_bang.rb
+++ b/lib/rubocop/rspec/let_bang.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+module RSpec
+  # Checks `let!` calls being used for test setup.
+  #
+  # @example
+  #   # Bad
+  #   let!(:my_product) { create(:product) }
+  #
+  #   it 'counts products' do
+  #     expect(Product.count).to eq(1)
+  #   end
+  #
+  #   # Good
+  #   let(:my_product) { create(:products) }
+  #
+  #   before { my_product }
+  #
+  #   it 'counts products' do
+  #     expect(Product.count).to eq(1)
+  #   end
+  class LetBang < RuboCop::Cop::RSpec::Cop
+    MSG = 'Do not use `let!`.'
+
+    def_node_search :let_bang, <<-PATTERN
+      (block $(send nil? :let! (sym $_)) args ...)
+    PATTERN
+
+    def on_block(node)
+      return unless example_group?(node)
+
+      let_bang(node) do |method_send, _method_name|
+        add_offense(method_send, location: :expression)
+      end
+    end
+  end
+end

--- a/spec/features/integration_spec.rb
+++ b/spec/features/integration_spec.rb
@@ -1,8 +1,18 @@
 require 'spec_helper'
 
-RSpec.feature 'end to end import' do
+feature 'end to end import' do
   include ActiveJob::TestHelper
-  let!(:country) do
+
+  subject do
+    SpreeShopifyImporter::Invoker.new(
+      credentials: {
+        api_key: '0a9445b7b067719a0af024610364ee34', password: '800f97d6ea1a768048851cdd99a9101a',
+        shop_domain: 'spree-shopify-importer-test-store.myshopify.com', api_version: '2019-10'
+      }
+    )
+  end
+
+  let(:country) do
     create(:country,
            name: 'Croatia',
            iso_name: 'CROATIA',
@@ -10,83 +20,74 @@ RSpec.feature 'end to end import' do
            iso3: 'HRV')
   end
 
-  it 'imports successfully' do
-    perform_enqueued_jobs do
-      SpreeShopifyImporter::Invoker.new(
-        credentials: {
-          api_key: '0a9445b7b067719a0af024610364ee34', password: '800f97d6ea1a768048851cdd99a9101a',
-          shop_domain: 'spree-shopify-importer-test-store.myshopify.com', api_version: '2019-10'
-        }
-      ).import!
+  describe 'import!' do
+    before do
+      country
     end
 
-    aggregate_failures 'items creation' do
-      expect(Spree::StockLocation.count).to eq 2
-      expect(Spree::Product.count).to eq 2
-      expect(Spree::Variant.count).to eq 4
-      expect(Spree::TaxCategory.count).to eq 1
-      expect(Spree.user_class.count).to eq 3
-      expect(Spree::Taxonomy.count).to eq 1
-      expect(Spree::Taxon.count).to eq 3
-      expect(Spree::Order.count).to eq 1
-      expect(Spree::LineItem.count).to eq 2
-      expect(Spree::Payment.count).to eq 1
-      expect(Spree::Shipment.count).to eq 3
-      expect(Spree::ShippingRate.count).to eq 3
-      expect(Spree::InventoryUnit.count).to eq 8
-      expect(Spree::Address.count).to eq 8
-      expect(Spree::ReturnAuthorization.count).to eq 1
-      expect(Spree::ReturnItem.count).to eq 1
-      expect(Spree::CustomerReturn.count).to eq 1
-      expect(Spree::Reimbursement.count).to eq 1
-      expect(Spree::Refund.count).to eq 1
-      expect(Spree::Zone.count).to eq 2
-      expect(Spree::TaxRate.count).to eq 2
-      expect(Spree::ShippingCategory.count).to eq 2
-      expect(Spree::ShippingMethod.count).to eq 4
-    end
-  end
+    it 'imports successfully' do
+      perform_enqueued_jobs do
+        subject.import!
+      end
 
-  it 'multiple imports successfully' do
-    perform_enqueued_jobs do
-      SpreeShopifyImporter::Invoker.new(
-        credentials: {
-          api_key: '0a9445b7b067719a0af024610364ee34', password: '800f97d6ea1a768048851cdd99a9101a',
-          shop_domain: 'spree-shopify-importer-test-store.myshopify.com', api_version: '2019-10'
-        }
-      ).import!
-      SpreeShopifyImporter::Invoker.new(
-        credentials: {
-          api_key: '0a9445b7b067719a0af024610364ee34', password: '800f97d6ea1a768048851cdd99a9101a',
-          shop_domain: 'spree-shopify-importer-test-store.myshopify.com', api_version: '2019-10'
-        }
-      ).import!
+      aggregate_failures 'items creation' do
+        expect(Spree::StockLocation.count).to eq 2
+        expect(Spree::Product.count).to eq 2
+        expect(Spree::Variant.count).to eq 4
+        expect(Spree::TaxCategory.count).to eq 1
+        expect(Spree.user_class.count).to eq 3
+        expect(Spree::Taxonomy.count).to eq 1
+        expect(Spree::Taxon.count).to eq 3
+        expect(Spree::Order.count).to eq 1
+        expect(Spree::LineItem.count).to eq 2
+        expect(Spree::Payment.count).to eq 1
+        expect(Spree::Shipment.count).to eq 3
+        expect(Spree::ShippingRate.count).to eq 3
+        expect(Spree::InventoryUnit.count).to eq 8
+        expect(Spree::Address.count).to eq 8
+        expect(Spree::ReturnAuthorization.count).to eq 1
+        expect(Spree::ReturnItem.count).to eq 1
+        expect(Spree::CustomerReturn.count).to eq 1
+        expect(Spree::Reimbursement.count).to eq 1
+        expect(Spree::Refund.count).to eq 1
+        expect(Spree::Zone.count).to eq 2
+        expect(Spree::TaxRate.count).to eq 2
+        expect(Spree::ShippingCategory.count).to eq 2
+        expect(Spree::ShippingMethod.count).to eq 4
+      end
     end
 
-    aggregate_failures 'items creation' do
-      expect(Spree::StockLocation.count).to eq 2
-      expect(Spree::Product.count).to eq 2
-      expect(Spree::Variant.count).to eq 4
-      expect(Spree::TaxCategory.count).to eq 1
-      expect(Spree.user_class.count).to eq 3
-      expect(Spree::Taxonomy.count).to eq 1
-      expect(Spree::Taxon.count).to eq 3
-      expect(Spree::Order.count).to eq 1
-      expect(Spree::LineItem.count).to eq 2
-      expect(Spree::Payment.count).to eq 1
-      expect(Spree::Shipment.count).to eq 3
-      expect(Spree::ShippingRate.count).to eq 3
-      expect(Spree::InventoryUnit.count).to eq 8
-      expect(Spree::Address.count).to eq 8
-      expect(Spree::ReturnAuthorization.count).to eq 1
-      expect(Spree::ReturnItem.count).to eq 1
-      expect(Spree::CustomerReturn.count).to eq 1
-      expect(Spree::Reimbursement.count).to eq 1
-      expect(Spree::Refund.count).to eq 1
-      expect(Spree::Zone.count).to eq 2
-      expect(Spree::TaxRate.count).to eq 2
-      expect(Spree::ShippingCategory.count).to eq 2
-      expect(Spree::ShippingMethod.count).to eq 4
+    it 'multiple imports successfully' do
+      perform_enqueued_jobs do
+        subject.import!
+        subject.import!
+      end
+
+      aggregate_failures 'items creation' do
+        expect(Spree::StockLocation.count).to eq 2
+        expect(Spree::Product.count).to eq 2
+        expect(Spree::Variant.count).to eq 4
+        expect(Spree::TaxCategory.count).to eq 1
+        expect(Spree.user_class.count).to eq 3
+        expect(Spree::Taxonomy.count).to eq 1
+        expect(Spree::Taxon.count).to eq 3
+        expect(Spree::Order.count).to eq 1
+        expect(Spree::LineItem.count).to eq 2
+        expect(Spree::Payment.count).to eq 1
+        expect(Spree::Shipment.count).to eq 3
+        expect(Spree::ShippingRate.count).to eq 3
+        expect(Spree::InventoryUnit.count).to eq 8
+        expect(Spree::Address.count).to eq 8
+        expect(Spree::ReturnAuthorization.count).to eq 1
+        expect(Spree::ReturnItem.count).to eq 1
+        expect(Spree::CustomerReturn.count).to eq 1
+        expect(Spree::Reimbursement.count).to eq 1
+        expect(Spree::Refund.count).to eq 1
+        expect(Spree::Zone.count).to eq 2
+        expect(Spree::TaxRate.count).to eq 2
+        expect(Spree::ShippingCategory.count).to eq 2
+        expect(Spree::ShippingMethod.count).to eq 4
+      end
     end
   end
 end

--- a/spec/services/spree_shopify_importer/data_feeds/create_spec.rb
+++ b/spec/services/spree_shopify_importer/data_feeds/create_spec.rb
@@ -1,41 +1,33 @@
 require 'spec_helper'
 
 RSpec.describe SpreeShopifyImporter::DataFeeds::Create, type: :service do
-  subject { described_class.new(shopify_object) }
+  subject { described_class.new(shopify_object, parent) }
+
+  let(:shopify_object) { build_stubbed(:shopify_product) }
+  let(:parent) { nil }
 
   describe 'save!' do
     context 'shopify product' do
-      let!(:shopify_object) { create(:shopify_product) }
-
       it 'creates shopify data feed' do
         expect { subject.save! }.to change(SpreeShopifyImporter::DataFeed, :count).by(1)
       end
 
       context 'saves' do
-        let!(:data_feed) { subject.save! }
+        it 'returns correct attributes' do
+          data_feed = subject.save!
 
-        it 'shopify object id' do
           expect(data_feed.shopify_object_id).to eq shopify_object.id
-        end
-
-        it 'shopify object type' do
           expect(data_feed.shopify_object_type).to eq 'ShopifyAPI::Product'
-        end
-
-        it 'shopify object as data feed' do
           expect(data_feed.data_feed).to eq shopify_object.to_json.to_s
-        end
-
-        it 'does not assigns parent' do
           expect(data_feed.parent).to be_nil
         end
 
         context 'with existing parent' do
-          let!(:parent) { create(:shopify_data_feed) }
-
-          subject { described_class.new(shopify_object, parent) }
+          let(:parent) { build_stubbed(:shopify_data_feed) }
 
           it 'assigns parent to data feed' do
+            data_feed = subject.save!
+
             expect(data_feed.parent).to eq parent
           end
         end

--- a/spec/services/spree_shopify_importer/data_parsers/adjustments/tax/base_data_spec.rb
+++ b/spec/services/spree_shopify_importer/data_parsers/adjustments/tax/base_data_spec.rb
@@ -7,7 +7,7 @@ describe SpreeShopifyImporter::DataParsers::Adjustments::Tax::BaseData, type: :s
     let(:spree_order) { create(:order_with_line_items) }
     let(:spree_line_item) { spree_order.line_items.first }
     let(:shopify_tax_line) { create(:shopify_tax_line) }
-    let!(:spree_tax_rate) { create(:tax_rate, zone: spree_order.tax_zone, tax_category: spree_line_item.tax_category) }
+    let(:spree_tax_rate) { create(:tax_rate, zone: spree_order.tax_zone, tax_category: spree_line_item.tax_category) }
     let(:result) do
       {
         order: spree_order,
@@ -17,6 +17,10 @@ describe SpreeShopifyImporter::DataParsers::Adjustments::Tax::BaseData, type: :s
         amount: shopify_tax_line.price,
         state: :closed
       }
+    end
+
+    before do
+      spree_tax_rate
     end
 
     it 'returns hash of tax adjustment attributes' do

--- a/spec/services/spree_shopify_importer/data_parsers/customer_returns/base_data_spec.rb
+++ b/spec/services/spree_shopify_importer/data_parsers/customer_returns/base_data_spec.rb
@@ -1,8 +1,9 @@
 require 'spec_helper'
 
 describe SpreeShopifyImporter::DataParsers::CustomerReturns::BaseData, type: :service do
-  let!(:shopify_refund) { create(:shopify_refund) }
   subject { described_class.new(shopify_refund) }
+
+  let(:shopify_refund) { create(:shopify_refund) }
 
   describe '#number' do
     it 'returns customer return number' do

--- a/spec/services/spree_shopify_importer/data_parsers/inventory_units/base_data_spec.rb
+++ b/spec/services/spree_shopify_importer/data_parsers/inventory_units/base_data_spec.rb
@@ -1,36 +1,43 @@
 require 'spec_helper'
 
 describe SpreeShopifyImporter::DataParsers::InventoryUnits::BaseData, type: :service do
-  let!(:spree_shipment) { create(:shipment) }
-  let!(:shopify_line_item) { create(:shopify_line_item) }
-  let!(:spree_variant) { create(:variant) }
-  let!(:spree_line_item) { create(:line_item, order: spree_shipment.order, variant: spree_variant) }
-
   subject { described_class.new(shopify_line_item, spree_shipment) }
 
-  before do
+  let(:shopify_line_item) { create(:shopify_line_item) }
+  let(:spree_shipment) { create(:shipment) }
+
+  let(:spree_variant) { create(:variant) }
+  let(:spree_line_item) { create(:line_item, order: spree_shipment.order, variant: spree_variant) }
+  let(:shopify_data_feed) do
     create(:shopify_data_feed,
            spree_object: spree_variant,
            shopify_object_type: 'ShopifyAPI::Variant',
            shopify_object_id: shopify_line_item.variant_id)
   end
 
-  describe '#attributes' do
-    let!(:result) do
-      {
-        order: spree_shipment.order,
-        variant: spree_variant,
-        line_item: spree_line_item,
-        state: :on_hand
-      }
-    end
+  before do
+    shopify_data_feed
+    spree_line_item
+  end
 
-    it 'returns hash od inventory unit attributes' do
-      expect(subject.attributes).to eq result
+  describe '#attributes' do
+    context 'when shipment is in on_hand state' do
+      let(:result) do
+        {
+          order: spree_shipment.order,
+          variant: spree_variant,
+          line_item: spree_line_item,
+          state: :on_hand
+        }
+      end
+
+      it 'returns hash of inventory unit attributes' do
+        expect(subject.attributes).to eq result
+      end
     end
 
     context 'when shipment is shipped' do
-      let!(:spree_shipment) { create(:shipment, state: :shipped) }
+      let(:spree_shipment) { create(:shipment, state: :shipped) }
 
       it 'returns hash od inventory unit attributes' do
         expect(subject.attributes[:state]).to eq :shipped

--- a/spec/services/spree_shopify_importer/data_parsers/line_items/base_data_spec.rb
+++ b/spec/services/spree_shopify_importer/data_parsers/line_items/base_data_spec.rb
@@ -1,17 +1,22 @@
 require 'spec_helper'
 
 describe SpreeShopifyImporter::DataParsers::LineItems::BaseData, type: :service do
+  subject { described_class.new(shopify_line_item, shopify_order) }
+
   let(:shopify_line_item) { create(:shopify_line_item) }
   let(:shopify_order) { create(:shopify_order, line_items: [shopify_line_item]) }
+
   let(:spree_variant) { create(:variant) }
-  let!(:variant_data_feed) do
+  let(:variant_data_feed) do
     create(:shopify_data_feed,
-           shopify_object_type: 'ShopifyAPI::Variant',
            shopify_object_id: shopify_line_item.variant_id,
+           shopify_object_type: 'ShopifyAPI::Variant',
            spree_object: spree_variant)
   end
 
-  subject { described_class.new(shopify_line_item, shopify_order) }
+  before do
+    variant_data_feed
+  end
 
   describe '#line_item_attributes' do
     let(:result) do
@@ -30,18 +35,15 @@ describe SpreeShopifyImporter::DataParsers::LineItems::BaseData, type: :service 
   end
 
   describe '#variant' do
-    it 'returns a spree variant' do
-      expect(subject.variant).to eq spree_variant
+    context 'when variant is present in data_feed' do
+      it 'returns a spree variant' do
+        expect(subject.variant).to eq spree_variant
+      end
     end
 
     context 'variant is missing', vcr: { cassette_name: 'shopify_import/data_parsers/line_item/missing_variant' } do
       let(:shopify_line_item) { create(:shopify_line_item, product_id: 11_055_169_028) }
-      let!(:variant_data_feed) do
-        create(:shopify_data_feed,
-               shopify_object_id: shopify_line_item.variant_id,
-               shopify_object_type: 'ShopifyAPI::Variant',
-               spree_object: nil)
-      end
+      let(:spree_variant) { nil }
 
       before { authenticate_with_shopify }
 

--- a/spec/services/spree_shopify_importer/data_parsers/orders/base_data_spec.rb
+++ b/spec/services/spree_shopify_importer/data_parsers/orders/base_data_spec.rb
@@ -3,42 +3,44 @@ require 'spec_helper'
 RSpec.describe SpreeShopifyImporter::DataParsers::Orders::BaseData, type: :service do
   subject { described_class.new(shopify_order) }
 
-  let(:shopify_order) { create(:shopify_order) }
-  let(:shopify_transaction) { create(:shopify_transaction, order: shopify_order) }
+  let(:shopify_order) { build_stubbed(:shopify_order) }
 
   describe '#user' do
-    let(:user) { create(:user) }
-    let!(:shopify_data_feed) do
-      create(:shopify_data_feed,
-             spree_object: user,
-             shopify_object_id: shopify_order.customer.id,
-             shopify_object_type: 'ShopifyAPI::Customer')
-    end
+    context 'when data_feed was imported' do
+      let(:shopify_data_feed) do
+        create(:shopify_data_feed,
+               spree_object: user,
+               shopify_object_id: shopify_order.customer.id,
+               shopify_object_type: 'ShopifyAPI::Customer')
+      end
+      let(:user) { create(:user) }
 
-    it 'returns spree user' do
-      expect(subject.user).to eq user
+      before do
+        shopify_data_feed
+      end
+
+      context 'when user is imported' do
+        it 'returns spree user' do
+          expect(subject.user).to eq user
+        end
+      end
+
+      context 'when user cannot be created' do
+        let(:user) { nil }
+
+        it 'returns nil' do
+          expect(subject.user).to be_nil
+        end
+      end
     end
 
     context 'where user is not imported' do
-      let!(:shopify_data_feed) { nil }
+      let(:shopify_data_feed) { nil }
 
-      it 'raise NoUserFound error and start user import job' do
+      it 'raises NoUserFound error and start user import job' do
         expect { subject.user }
           .to raise_error(SpreeShopifyImporter::DataParsers::Orders::UserNotFound)
           .and enqueue_job(SpreeShopifyImporter::Importers::UserImporterJob)
-      end
-
-      context 'when customer data feed was imported but user cannot be created' do
-        let!(:shopify_data_feed) do
-          create(:shopify_data_feed,
-                 spree_object: nil,
-                 shopify_object_id: shopify_order.customer.id,
-                 shopify_object_type: 'ShopifyAPI::Customer')
-        end
-
-        it 'return nil' do
-          expect(subject.user).to be_nil
-        end
       end
     end
   end
@@ -55,16 +57,18 @@ RSpec.describe SpreeShopifyImporter::DataParsers::Orders::BaseData, type: :servi
         item_count: shopify_order.line_items.sum(&:quantity)
       }
     end
+
     let(:order_totals) do
       {
         total: shopify_order.total_price,
         item_total: shopify_order.total_line_items_price,
         additional_tax_total: shopify_order.total_tax,
         promo_total: -shopify_order.total_discounts.to_d,
-        payment_total: shopify_transaction.amount.to_d,
-        shipment_total: shopify_order.shipping_lines.sum { |sl| sl.price.to_d }
+        payment_total: payment_total,
+        shipment_total: shopify_order.shipping_lines.sum { |shipping_line| shipping_line.price.to_d }
       }
     end
+
     let(:order_states) do
       {
         state: 'complete',
@@ -72,9 +76,15 @@ RSpec.describe SpreeShopifyImporter::DataParsers::Orders::BaseData, type: :servi
         shipment_state: 'shipped'
       }
     end
+
     let(:result) do
-      [base_order_attributes, order_totals, order_states].inject(&:merge)
+      [
+        base_order_attributes,
+        order_totals,
+        order_states
+      ].inject(&:merge)
     end
+
     let(:states_getter) { instance_double(SpreeShopifyImporter::DataParsers::Orders::StatesGetter) }
 
     before do
@@ -82,32 +92,29 @@ RSpec.describe SpreeShopifyImporter::DataParsers::Orders::BaseData, type: :servi
       expect(states_getter).to receive(:order_state).and_return('complete')
       expect(states_getter).to receive(:payment_state).and_return('paid')
       expect(states_getter).to receive(:shipment_state).and_return('shipped')
-      allow_any_instance_of(ShopifyAPI::Order).to receive(:transactions).and_return([shopify_transaction])
     end
 
-    it 'prepare hash of order attributes' do
-      expect(subject.attributes).to eq result
+    context 'when single transaction' do
+      let(:shopify_transaction) { build_stubbed(:shopify_transaction, order: shopify_order) }
+      let(:payment_total) { shopify_transaction.amount.to_d }
+
+      before do
+        expect_any_instance_of(ShopifyAPI::Order).to receive(:transactions).and_return([shopify_transaction])
+      end
+
+      it 'prepare hash of order attributes' do
+        expect(subject.attributes).to eq result
+      end
     end
 
     context 'with multiple transactions' do
-      let(:shopify_order) { build_stubbed(:shopify_order) }
-      let(:shopify_transaction1) { build_stubbed(:shopify_transaction, order: shopify_order) }
-      let(:shopify_transaction2) { build_stubbed(:shopify_transaction, order: shopify_order) }
+      let(:first_shopify_transaction) { build_stubbed(:shopify_transaction, order: shopify_order) }
+      let(:second_shopify_transaction) { build_stubbed(:shopify_transaction, order: shopify_order) }
+      let(:payment_total) { first_shopify_transaction.amount.to_d + second_shopify_transaction.amount.to_d }
 
       before do
         expect_any_instance_of(ShopifyAPI::Order)
-          .to receive(:transactions).and_return([shopify_transaction1, shopify_transaction2])
-      end
-
-      let(:order_totals) do
-        {
-          total: shopify_order.total_price,
-          item_total: shopify_order.total_line_items_price,
-          additional_tax_total: shopify_order.total_tax,
-          promo_total: -shopify_order.total_discounts.to_d,
-          payment_total: shopify_transaction1.amount.to_d + shopify_transaction2.amount.to_d,
-          shipment_total: shopify_order.shipping_lines.sum { |sl| sl.price.to_d }
-        }
+          .to receive(:transactions).and_return([first_shopify_transaction, second_shopify_transaction])
       end
 
       it 'prepare hash of order attributes' do
@@ -116,7 +123,7 @@ RSpec.describe SpreeShopifyImporter::DataParsers::Orders::BaseData, type: :servi
     end
   end
 
-  context '#timestamps' do
+  describe '#timestamps' do
     let(:order_timestamps) do
       {
         completed_at: shopify_order.created_at,

--- a/spec/services/spree_shopify_importer/data_parsers/products/base_data_spec.rb
+++ b/spec/services/spree_shopify_importer/data_parsers/products/base_data_spec.rb
@@ -2,11 +2,12 @@ require 'spec_helper'
 
 RSpec.describe SpreeShopifyImporter::DataParsers::Products::BaseData, type: :service do
   subject { described_class.new(shopify_product) }
-  let!(:shipping_category) { create(:shipping_category, name: I18n.t(:shopify)) }
+
   let(:shopify_product) { create(:shopify_product) }
 
   describe '#attributes' do
     context 'with sample product' do
+      let(:shipping_category) { build_stubbed(:shipping_category, name: I18n.t(:shopify)) }
       let(:product_attributes) do
         {
           name: shopify_product.title,
@@ -19,6 +20,10 @@ RSpec.describe SpreeShopifyImporter::DataParsers::Products::BaseData, type: :ser
         }
       end
 
+      before do
+        expect(Spree::ShippingCategory).to receive(:find_or_create_by!).with(name: 'Shopify').and_return(shipping_category)
+      end
+
       it 'prepares hash of attributes' do
         expect(subject.attributes).to eq product_attributes
       end
@@ -26,10 +31,8 @@ RSpec.describe SpreeShopifyImporter::DataParsers::Products::BaseData, type: :ser
   end
 
   describe '#tags' do
-    let(:product_tags) { shopify_product.tags }
-
     it 'prepares list tags' do
-      expect(subject.tags).to eq product_tags
+      expect(subject.tags).to eq shopify_product.tags
     end
   end
 

--- a/spec/services/spree_shopify_importer/data_parsers/promotions/base_data_spec.rb
+++ b/spec/services/spree_shopify_importer/data_parsers/promotions/base_data_spec.rb
@@ -1,8 +1,9 @@
 require 'spec_helper'
 
 describe SpreeShopifyImporter::DataParsers::Promotions::BaseData, type: :service do
-  let!(:shopify_discount_code) { create(:shopify_discount_code) }
   subject { described_class.new(shopify_discount_code) }
+
+  let(:shopify_discount_code) { build_stubbed(:shopify_discount_code) }
 
   describe '#attributes' do
     let(:result) do

--- a/spec/services/spree_shopify_importer/data_parsers/refunds/base_data_spec.rb
+++ b/spec/services/spree_shopify_importer/data_parsers/refunds/base_data_spec.rb
@@ -1,21 +1,24 @@
 require 'spec_helper'
 
 describe SpreeShopifyImporter::DataParsers::Refunds::BaseData, type: :service do
-  let(:shopify_refund) { create(:shopify_refund) }
-  let(:shopify_transaction) { create(:shopify_transaction, parent_id: 12_345) }
-  let(:spree_reimbursement) { create(:reimbursement) }
-
   subject { described_class.new(shopify_refund, shopify_transaction, spree_reimbursement) }
+
+  let(:shopify_refund)      { build_stubbed(:shopify_refund) }
+  let(:shopify_transaction) { build_stubbed(:shopify_transaction, parent_id: 12_345) }
+  let(:spree_reimbursement) { build_stubbed(:reimbursement) }
 
   describe '#attributes' do
     let(:payment) { create(:payment) }
+
     let(:reason) { Spree::RefundReason.find_by!(name: I18n.t(:shopify)) }
-    let!(:shopify_data_feed) do
+
+    let(:shopify_data_feed) do
       create(:shopify_data_feed,
              shopify_object_id: shopify_transaction.parent_id,
              shopify_object_type: 'ShopifyAPI::Transaction',
              spree_object: payment)
     end
+
     let(:result) do
       {
         payment: payment,
@@ -24,6 +27,10 @@ describe SpreeShopifyImporter::DataParsers::Refunds::BaseData, type: :service do
         reason: reason,
         reimbursement: spree_reimbursement
       }
+    end
+
+    before do
+      shopify_data_feed
     end
 
     it 'returns hash of refund attributes' do

--- a/spec/services/spree_shopify_importer/data_parsers/stock_locations/base_data_spec.rb
+++ b/spec/services/spree_shopify_importer/data_parsers/stock_locations/base_data_spec.rb
@@ -2,14 +2,15 @@ require 'spec_helper'
 
 RSpec.describe SpreeShopifyImporter::DataParsers::StockLocations::BaseData, type: :service do
   subject { described_class.new(shopify_location) }
+
   before do
     expect(Spree::Country).to receive(:find_by).with(iso: 'CA', name: 'Canada').and_return(country)
     expect(Spree::State).to receive(:find_by).with(country_id: country.id, abbr: 'AB').and_return(state)
   end
 
   let(:shopify_location) { build_stubbed(:shopify_location) }
-  let!(:country) { build_stubbed(:country, iso: 'CA', name: 'Canada') }
-  let!(:state) { build_stubbed(:state, country: country, abbr: 'AB') }
+  let(:country) { build_stubbed(:country, iso: 'CA', name: 'Canada') }
+  let(:state) { build_stubbed(:state, country: country, abbr: 'AB') }
 
   describe '#attributes' do
     let(:result) do

--- a/spec/services/spree_shopify_importer/data_parsers/tax_rates/base_data_spec.rb
+++ b/spec/services/spree_shopify_importer/data_parsers/tax_rates/base_data_spec.rb
@@ -6,9 +6,9 @@ describe SpreeShopifyImporter::DataParsers::TaxRates::BaseData, type: :service d
   describe '#attributes' do
     let(:shopify_object) { build_stubbed(:shopify_country) }
     let(:spree_zone) { build_stubbed(:zone, name: 'Domestic/Poland/GENERAL PROFILE') }
-    let!(:tax_category) { create(:tax_category, name: 'GENERAL PROFILE/18869387313') }
+    let(:tax_category) { create(:tax_category, name: 'GENERAL PROFILE/18869387313') }
     let(:calculator) { Spree::Calculator::ShopifyTax.last }
-    let!(:shop_data_feed) do
+    let(:shop_data_feed) do
       create(:shopify_data_feed,
              shopify_object_type: 'ShopifyAPI::Shop',
              data_feed: '{"taxes_included":true}')
@@ -22,6 +22,11 @@ describe SpreeShopifyImporter::DataParsers::TaxRates::BaseData, type: :service d
         included_in_price: JSON.parse(shop_data_feed.data_feed)['taxes_included'],
         show_rate_in_label: false
       }
+    end
+
+    before do
+      tax_category
+      shop_data_feed
     end
 
     it 'returns hash of tax rate attributes' do

--- a/spec/services/spree_shopify_importer/data_parsers/taxons/base_data_spec.rb
+++ b/spec/services/spree_shopify_importer/data_parsers/taxons/base_data_spec.rb
@@ -1,8 +1,9 @@
 require 'spec_helper'
 
-RSpec.describe SpreeShopifyImporter::DataParsers::Taxons::BaseData, type: :service do
-  let(:shopify_custom_collection) { create(:shopify_custom_collection) }
+describe SpreeShopifyImporter::DataParsers::Taxons::BaseData, type: :service do
   subject { described_class.new(shopify_custom_collection) }
+
+  let(:shopify_custom_collection) { build_stubbed(:shopify_custom_collection) }
 
   describe '#attributes' do
     let(:result) do
@@ -19,9 +20,10 @@ RSpec.describe SpreeShopifyImporter::DataParsers::Taxons::BaseData, type: :servi
   end
 
   describe '#product_ids' do
-    let!(:shopify_product) { create(:shopify_product) }
-    let!(:spree_product) { create(:product) }
-    let!(:shopify_data_feed) do
+    let(:shopify_product) { build_stubbed(:shopify_product) }
+    let(:spree_product) { build_stubbed(:product) }
+
+    let(:shopify_data_feed) do
       create(:shopify_data_feed,
              spree_object: spree_product,
              shopify_object_id: shopify_product.id,
@@ -29,7 +31,8 @@ RSpec.describe SpreeShopifyImporter::DataParsers::Taxons::BaseData, type: :servi
     end
 
     before do
-      allow(shopify_custom_collection).to receive(:products).and_return([shopify_product])
+      shopify_data_feed
+      expect(shopify_custom_collection).to receive(:products).and_return([shopify_product])
     end
 
     it 'returns array of products ids' do
@@ -38,12 +41,16 @@ RSpec.describe SpreeShopifyImporter::DataParsers::Taxons::BaseData, type: :servi
   end
 
   describe '#taxonomy' do
-    it 'creates spree taxonomy' do
-      expect { subject.taxonomy }.to change(Spree::Taxonomy, :count).by(1)
+    context 'when taxonomy is not exists' do
+      it 'creates spree taxonomy' do
+        expect { subject.taxonomy }.to change(Spree::Taxonomy, :count).by(1)
+      end
     end
 
-    it 'assigns proper name to taxonomy' do
-      expect(subject.taxonomy.name).to eq I18n.t('shopify_custom_collections')
+    context 'when taxonomy already exists' do
+      it 'assigns proper name to taxonomy' do
+        expect(subject.taxonomy.name).to eq I18n.t('shopify_custom_collections')
+      end
     end
   end
 end

--- a/spec/services/spree_shopify_importer/data_parsers/variants/base_data_spec.rb
+++ b/spec/services/spree_shopify_importer/data_parsers/variants/base_data_spec.rb
@@ -1,9 +1,10 @@
 require 'spec_helper'
 
-RSpec.describe SpreeShopifyImporter::DataParsers::Variants::BaseData, type: :service do
-  let(:spree_product) { create(:product) }
-  let(:shopify_variant) { create(:shopify_variant) }
+describe SpreeShopifyImporter::DataParsers::Variants::BaseData, type: :service do
   subject { described_class.new(shopify_variant, spree_product) }
+
+  let(:shopify_variant) { build_stubbed(:shopify_variant) }
+  let(:spree_product)   { build_stubbed(:product) }
 
   context '#attributes' do
     let(:result) do
@@ -24,20 +25,20 @@ RSpec.describe SpreeShopifyImporter::DataParsers::Variants::BaseData, type: :ser
 
   context '#option_value_ids' do
     let(:option_type) { create(:option_type) }
-    let!(:f_option_value) do
-      create(:option_value, name: shopify_variant.option1.strip.downcase, option_type: option_type)
-    end
-    let!(:s_option_value) do
-      create(:option_value, name: shopify_variant.option2.strip.downcase, option_type: option_type)
-    end
-    let(:result) { [f_option_value.id, s_option_value.id, t_option_value.id] }
 
     context 'with valid product associations' do
-      let!(:t_option_value) do
-        create(:option_value, name: shopify_variant.option3.strip.downcase, option_type: option_type)
-      end
+      let(:f_option_value) { create(:option_value, name: shopify_variant.option1.strip.downcase, option_type: option_type) }
+      let(:s_option_value) { create(:option_value, name: shopify_variant.option2.strip.downcase, option_type: option_type) }
+      let(:t_option_value) { create(:option_value, name: shopify_variant.option3.strip.downcase, option_type: option_type) }
 
-      before { spree_product.option_types << option_type }
+      let(:result) { [f_option_value.id, s_option_value.id, t_option_value.id] }
+
+      before do
+        f_option_value
+        s_option_value
+        t_option_value
+        spree_product.option_types << option_type
+      end
 
       it 'returns option value ids' do
         expect(subject.option_value_ids).to match_array(result)
@@ -45,10 +46,6 @@ RSpec.describe SpreeShopifyImporter::DataParsers::Variants::BaseData, type: :ser
     end
 
     context "when product has't got option types" do
-      let!(:t_option_value) do
-        create(:option_value, name: shopify_variant.option3.strip.downcase, option_type: option_type)
-      end
-
       it 'raises record not found' do
         expect do
           subject.option_value_ids
@@ -67,21 +64,17 @@ RSpec.describe SpreeShopifyImporter::DataParsers::Variants::BaseData, type: :ser
     end
   end
 
-  context '#track_inventory?' do
-    context 'shopify variant has inventory_management == shopify' do
-      let(:shopify_variant) { create(:shopify_variant, inventory_management: 'shopify') }
+  describe '#track_inventory?' do
+    context 'when shopify variant has inventory_management shopify' do
+      let(:shopify_variant) { build_stubbed(:shopify_variant, inventory_management: 'shopify') }
 
-      it 'returns true' do
-        expect(subject).to be_track_inventory
-      end
+      it { expect(subject).to be_track_inventory }
     end
 
-    context 'shopify variant has inventory_management other than shopify' do
-      let(:shopify_variant) { create(:shopify_variant, inventory_management: 'global') }
+    context 'when shopify variant has inventory_management other than shopify' do
+      let(:shopify_variant) { build_stubbed(:shopify_variant, inventory_management: 'global') }
 
-      it 'returns true' do
-        expect(subject).not_to be_track_inventory
-      end
+      it { expect(subject).not_to be_track_inventory }
     end
   end
 end

--- a/spec/services/spree_shopify_importer/data_parsers/zones/base_data_spec.rb
+++ b/spec/services/spree_shopify_importer/data_parsers/zones/base_data_spec.rb
@@ -2,12 +2,18 @@ require 'spec_helper'
 
 RSpec.describe SpreeShopifyImporter::DataParsers::Zones::BaseData do
   subject { described_class.new(shopify_object, parent_object, spree_zone_kind) }
-  let(:parent_object) { build_stubbed(:shopify_shipping_zone) }
+
   let(:shopify_object) { build_stubbed(:shopify_country) }
-  let!(:tax_category) { create(:tax_category, name: 'GENERAL PROFILE/18869387313') }
+  let(:parent_object) { build_stubbed(:shopify_shipping_zone) }
   let(:spree_zone_kind) { 'country' }
 
   describe '#attributes' do
+    let(:tax_category) { create(:tax_category, name: 'GENERAL PROFILE/18869387313') }
+
+    before do
+      tax_category
+    end
+
     context 'with sample shopify_shipping_zone' do
       let(:zone_attributes) do
         {

--- a/spec/services/spree_shopify_importer/data_savers/addresses/address_updater_spec.rb
+++ b/spec/services/spree_shopify_importer/data_savers/addresses/address_updater_spec.rb
@@ -1,77 +1,55 @@
 require 'spec_helper'
 
 describe SpreeShopifyImporter::DataSavers::Addresses::AddressUpdater, type: :service do
-  let(:shopify_data_feed) do
-    create(:shopify_data_feed,
-           shopify_object_id: shopify_address.id,
-           shopify_object_type: 'ShopifyAPI::Address',
-           data_feed: shopify_address.to_json)
-  end
-
   subject { described_class.new(shopify_data_feed, spree_address) }
 
-  before { authenticate_with_shopify }
+  let(:shopify_data_feed) do
+    build_stubbed(:shopify_data_feed,
+                  shopify_object_id: shopify_address.id,
+                  shopify_object_type: 'ShopifyAPI::Address',
+                  data_feed: shopify_address.to_json)
+  end
+  let(:spree_address) { create(:address) }
 
   describe '#update!' do
-    let(:shopify_address) { create(:shopify_address) }
-    let(:address_data_feed) { create(:shopify_data_feed, data_feed: shopify_address.to_json) }
-    let!(:spree_address) { create(:address) }
-
-    it 'does not create spree address' do
-      expect { subject.update! }.not_to change(Spree::Address, :count)
+    let(:shopify_address) { build_stubbed(:shopify_address) }
+    let(:parser) { instance_double(SpreeShopifyImporter::DataParsers::Addresses::BaseData) }
+    let(:state) { build_stubbed(:state) }
+    let(:country) { build_stubbed(:country) }
+    let(:attributes) do
+      {
+        firstname: shopify_address.first_name,
+        lastname: shopify_address.last_name,
+        address1: shopify_address.address1,
+        address2: shopify_address.address2,
+        company: shopify_address.company,
+        phone: shopify_address.phone,
+        city: shopify_address.city,
+        zipcode: shopify_address.zip,
+        state: state,
+        country: country
+      }
     end
 
-    context 'sets address attributes' do
-      before { subject.update! }
-
-      it 'firstname' do
-        expect(spree_address.firstname).to eq shopify_address.first_name
-      end
-
-      it 'lastname' do
-        expect(spree_address.lastname).to eq shopify_address.last_name
-      end
-
-      it 'address1' do
-        expect(spree_address.address1).to eq shopify_address.address1
-      end
-
-      it 'address2' do
-        expect(spree_address.address2).to eq shopify_address.address2
-      end
-
-      it 'company' do
-        expect(spree_address.company).to eq shopify_address.company
-      end
-
-      it 'city' do
-        expect(spree_address.city).to eq shopify_address.city
-      end
-
-      it 'phone' do
-        expect(spree_address.phone).to eq shopify_address.phone
-      end
-
-      it 'zipcode' do
-        expect(spree_address.zipcode).to eq shopify_address.zip
-      end
+    before do
+      expect(ShopifyAPI::Address).to receive(:new).with(JSON.parse(shopify_address.to_json)).and_return(shopify_address)
+      expect(SpreeShopifyImporter::DataParsers::Addresses::BaseData).to receive(:new).with(shopify_address).and_return(parser)
+      expect(parser).to receive(:attributes).and_return(attributes)
     end
 
-    context 'associations' do
-      let(:country) { Spree::Country.find_by!(iso: shopify_address.country_code) }
-      let(:state) { Spree::State.find_by(abbr: shopify_address.province_code) }
+    it 'sets correct attributes' do
+      subject.update!
 
-      it 'assigns country to address' do
-        subject.update!
-
-        expect(spree_address.country).to eq country
-      end
-
-      it 'assigns state to address' do
-        subject.update!
-
-        expect(spree_address.state).to eq state
-      end
+      expect(spree_address.firstname).to eq shopify_address.first_name
+      expect(spree_address.lastname).to eq shopify_address.last_name
+      expect(spree_address.address1).to eq shopify_address.address1
+      expect(spree_address.address2).to eq shopify_address.address2
+      expect(spree_address.company).to eq shopify_address.company
+      expect(spree_address.city).to eq shopify_address.city
+      expect(spree_address.phone).to eq shopify_address.phone
+      expect(spree_address.zipcode).to eq shopify_address.zip
+      expect(spree_address.state.id).to eq state.id
+      expect(spree_address.country.id).to eq country.id
     end
   end
 end

--- a/spec/services/spree_shopify_importer/data_savers/adjustments/tax_creator_spec.rb
+++ b/spec/services/spree_shopify_importer/data_savers/adjustments/tax_creator_spec.rb
@@ -3,50 +3,47 @@ require 'spec_helper'
 describe SpreeShopifyImporter::DataSavers::Adjustments::TaxCreator, type: :service do
   subject { described_class.new(spree_line_item, shopify_tax_line, spree_order) }
 
-  describe '#save!' do
-    let(:spree_order) { create(:order_with_line_items) }
-    let(:spree_line_item) { spree_order.line_items.first }
-    let(:shopify_tax_line) { create(:shopify_tax_line) }
-    let!(:spree_tax_rate) { create(:tax_rate, tax_category: spree_line_item.tax_category, zone: spree_order.tax_zone) }
+  let(:spree_line_item) { build_stubbed(:line_item) }
+  let(:shopify_tax_line) { build_stubbed(:shopify_tax_line) }
+  let(:spree_order) { create(:order_with_line_items) }
+
+  describe '#create!' do
+    let(:parser) { instance_double(SpreeShopifyImporter::DataParsers::Adjustments::Tax::BaseData) }
+    let(:spree_tax_rate) { build_stubbed(:tax_rate) }
+    let(:attributes) do
+      {
+        order: spree_order,
+        adjustable: spree_order,
+        label: shopify_tax_line.title,
+        source: spree_tax_rate,
+        amount: shopify_tax_line.price,
+        state: :closed
+      }
+    end
+
+    before do
+      expect(SpreeShopifyImporter::DataParsers::Adjustments::Tax::BaseData).to receive(:new).with(spree_line_item, shopify_tax_line, spree_order).and_return(parser)
+      expect(parser).to receive(:attributes).and_return(attributes)
+    end
 
     it 'creates tax adjustment' do
       expect { subject.create! }.to change(Spree::Adjustment, :count).by(1)
     end
 
-    context 'sets an adjustment attributes' do
-      let(:adjustment) { Spree::Adjustment.last }
+    it 'sets correct attributes' do
+      adjustment = subject.create!
 
-      before { subject.create! }
-
-      it 'label' do
-        expect(adjustment.label).to eq shopify_tax_line.title
-      end
-
-      it 'amount' do
-        expect(adjustment.amount).to eq shopify_tax_line.price
-      end
-
-      it 'state' do
-        expect(adjustment).to be_closed
-      end
+      expect(adjustment.label).to eq shopify_tax_line.title
+      expect(adjustment.amount).to eq shopify_tax_line.price
+      expect(adjustment).to be_closed
     end
 
-    context 'sets an adjustment associations' do
-      let(:adjustment) { Spree::Adjustment.last }
+    it 'sets correct associations' do
+      adjustment = subject.create!
 
-      before { subject.create! }
-
-      it 'order' do
-        expect(adjustment.order).to eq spree_order
-      end
-
-      it 'adjustable' do
-        expect(adjustment.adjustable).to eq spree_order
-      end
-
-      it 'source' do
-        expect(adjustment.source).to eq spree_tax_rate
-      end
+      expect(adjustment.order).to eq spree_order
+      expect(adjustment.adjustable).to eq spree_order
+      expect(adjustment.source).to eq spree_tax_rate
     end
   end
 end

--- a/spec/services/spree_shopify_importer/data_savers/images/image_creator_spec.rb
+++ b/spec/services/spree_shopify_importer/data_savers/images/image_creator_spec.rb
@@ -2,13 +2,16 @@ require 'spec_helper'
 
 describe SpreeShopifyImporter::DataSavers::Images::ImageCreator, type: :service do
   subject { described_class.new(shopify_data_feed, spree_object) }
-  let(:spree_image) { Spree::Image.last }
+
   let(:shopify_data_feed) do
     create(:shopify_data_feed,
            shopify_object_type: 'ShopifyAPI::Image',
            shopify_object_id: shopify_image.id,
            data_feed: shopify_image.to_json)
   end
+  let(:spree_object) { create(:product) }
+
+  let(:spree_image) { subject.create! }
 
   describe '#save!', vcr: { cassette_name: 'shopify_import/creators/image_creator' } do
     let(:shopify_image) do
@@ -18,13 +21,9 @@ describe SpreeShopifyImporter::DataSavers::Images::ImageCreator, type: :service 
     end
 
     context 'with spree product' do
-      let!(:spree_object) { create(:product) }
-
       it_behaves_like 'create spree image'
 
       context 'sets associations' do
-        before { subject.create! }
-
         it 'viewable object' do
           expect(spree_image.viewable).to eq spree_object.master
         end
@@ -32,13 +31,11 @@ describe SpreeShopifyImporter::DataSavers::Images::ImageCreator, type: :service 
     end
 
     context 'with spree variant' do
-      let!(:spree_object) { create(:variant) }
+      let(:spree_object) { create(:variant) }
 
       it_behaves_like 'create spree image'
 
       context 'sets associations' do
-        before { subject.create! }
-
         it 'viewable object' do
           expect(spree_image.viewable).to eq spree_object
         end

--- a/spec/services/spree_shopify_importer/data_savers/images/image_updater_spec.rb
+++ b/spec/services/spree_shopify_importer/data_savers/images/image_updater_spec.rb
@@ -1,7 +1,8 @@
 require 'spec_helper'
 
 describe SpreeShopifyImporter::DataSavers::Images::ImageUpdater, type: :service do
-  subject { described_class.new(shopify_data_feed, spree_image, spree_object) }
+  subject { described_class.new(shopify_data_feed, spree_image) }
+
   let(:spree_image) { create(:image) }
   let(:shopify_data_feed) do
     create(:shopify_data_feed,
@@ -17,16 +18,6 @@ describe SpreeShopifyImporter::DataSavers::Images::ImageUpdater, type: :service 
                    'products/Screenshot_2017-03-03_14.45.16_29b97e8b-f008-460f-8733-b33d551d7140.png?v=1496631699')
     end
 
-    context 'with spree product' do
-      let!(:spree_object) { create(:product) }
-
-      it_behaves_like 'updates spree image'
-    end
-
-    context 'with spree variant' do
-      let!(:spree_object) { create(:variant) }
-
-      it_behaves_like 'updates spree image'
-    end
+    it_behaves_like 'updates spree image'
   end
 end

--- a/spec/services/spree_shopify_importer/data_savers/inventory_units/inventory_units_creator_spec.rb
+++ b/spec/services/spree_shopify_importer/data_savers/inventory_units/inventory_units_creator_spec.rb
@@ -2,17 +2,19 @@ require 'spec_helper'
 
 describe SpreeShopifyImporter::DataSavers::InventoryUnits::InventoryUnitsCreator, type: :service do
   subject { described_class.new(shopify_line_item, spree_shipment) }
+
   before  { authenticate_with_shopify }
   after   { ShopifyAPI::Base.clear_session }
 
   describe '#create!', vcr: { cassette_name: 'shopify/base_order' } do
-    let!(:spree_shipment) { create(:shipment) }
-    let!(:shopify_order) { ShopifyAPI::Order.find(5_182_437_124) }
-    let!(:shopify_line_item) { shopify_order.line_items.first }
-    let!(:spree_variant) { create(:variant) }
-    let!(:spree_line_item) { create(:line_item, order: spree_shipment.order, variant: spree_variant) }
+    let(:spree_shipment) { create(:shipment) }
+    let(:shopify_order) { ShopifyAPI::Order.find(5_182_437_124) }
+    let(:shopify_line_item) { shopify_order.line_items.first }
+    let(:spree_variant) { create(:variant) }
+    let(:spree_line_item) { create(:line_item, order: spree_shipment.order, variant: spree_variant) }
 
     before do
+      spree_line_item
       create(:shopify_data_feed,
              spree_object: spree_variant,
              shopify_object_type: 'ShopifyAPI::Variant',

--- a/spec/services/spree_shopify_importer/data_savers/line_items/line_item_creator_spec.rb
+++ b/spec/services/spree_shopify_importer/data_savers/line_items/line_item_creator_spec.rb
@@ -2,15 +2,17 @@ require 'spec_helper'
 
 describe SpreeShopifyImporter::DataSavers::LineItems::LineItemCreator, type: :service do
   subject { described_class.new(shopify_line_item, shopify_order, spree_order) }
+
+  let(:spree_order) { create(:order) }
+
   before  { authenticate_with_shopify }
   after   { ShopifyAPI::Base.clear_session }
 
   describe '#create', vcr: { cassette_name: 'shopify/base_order' } do
-    let(:spree_order) { create(:order) }
     let(:shopify_order) { ShopifyAPI::Order.find(5_182_437_124) }
     let(:shopify_line_item) { shopify_order.line_items.first }
     let(:variant) { create(:variant) }
-    let!(:data_feed) do
+    let(:data_feed) do
       create(:shopify_data_feed,
              spree_object: variant,
              shopify_object_id: shopify_line_item.variant_id,
@@ -18,40 +20,28 @@ describe SpreeShopifyImporter::DataSavers::LineItems::LineItemCreator, type: :se
     end
     let(:line_item) { Spree::LineItem.find_by(variant_id: variant.id) }
 
+    before do
+      data_feed
+    end
+
     it 'creates spree line item' do
       expect { subject.create }.to change(Spree::LineItem, :count).by(1)
     end
 
-    context 'associations' do
-      before { subject.create }
+    it 'sets correct associations' do
+      subject.create
 
-      it 'assigns proper variant to spree line item' do
-        expect(line_item.variant).to eq variant
-      end
-
-      it 'assigns a line item to order' do
-        expect(line_item.order).to eq spree_order
-      end
+      expect(line_item.variant).to eq variant
+      expect(line_item.order).to eq spree_order
     end
 
-    context 'line item attributes' do
-      before { subject.create }
+    it 'sets correct attributes' do
+      subject.create
 
-      it 'sets quantity' do
-        expect(line_item.quantity).to eq shopify_line_item.quantity
-      end
-
-      it 'sets price' do
-        expect(line_item.price).to eq shopify_line_item.price.to_d
-      end
-
-      it 'sets currency' do
-        expect(line_item.currency).to eq shopify_order.currency
-      end
-
-      it 'sets adjustment_total' do
-        expect(line_item.adjustment_total).to eq(- shopify_line_item.total_discount.to_d)
-      end
+      expect(line_item.quantity).to eq shopify_line_item.quantity
+      expect(line_item.price).to eq shopify_line_item.price.to_d
+      expect(line_item.currency).to eq shopify_order.currency
+      expect(line_item.adjustment_total).to eq(- shopify_line_item.total_discount.to_d)
     end
   end
 end

--- a/spec/services/spree_shopify_importer/data_savers/option_types/option_type_creator_spec.rb
+++ b/spec/services/spree_shopify_importer/data_savers/option_types/option_type_creator_spec.rb
@@ -2,6 +2,7 @@ require 'spec_helper'
 
 describe SpreeShopifyImporter::DataSavers::OptionTypes::OptionTypeCreator, type: :service do
   subject { described_class.new(shopify_option) }
+
   let(:shopify_option) { create(:shopify_single_option) }
 
   describe '#create!' do
@@ -36,7 +37,11 @@ describe SpreeShopifyImporter::DataSavers::OptionTypes::OptionTypeCreator, type:
     end
 
     context 'if already created' do
-      let!(:option_type) { create(:option_type, name: shopify_option.name) }
+      let(:option_type) { create(:option_type, name: shopify_option.name) }
+
+      before do
+        option_type
+      end
 
       it 'does not create option type' do
         expect { subject.create! }.not_to change(Spree::OptionType, :count)

--- a/spec/services/spree_shopify_importer/data_savers/option_values/option_value_creator_spec.rb
+++ b/spec/services/spree_shopify_importer/data_savers/option_values/option_value_creator_spec.rb
@@ -2,6 +2,7 @@ require 'spec_helper'
 
 describe SpreeShopifyImporter::DataSavers::OptionValues::OptionValueCreator, type: :service do
   subject { described_class.new(shopify_value, spree_option_type) }
+
   let(:shopify_value) { 'Amethyst' }
   let(:spree_option_type) { create(:option_type) }
 
@@ -31,7 +32,11 @@ describe SpreeShopifyImporter::DataSavers::OptionValues::OptionValueCreator, typ
     end
 
     context 'if already created' do
-      let!(:spree_option_value) { create(:option_value, name: shopify_value, option_type: spree_option_type) }
+      let(:spree_option_value) { create(:option_value, name: shopify_value, option_type: spree_option_type) }
+
+      before do
+        spree_option_value
+      end
 
       it 'does not create option value' do
         expect { subject.create! }.not_to change(Spree::OptionValue, :count)

--- a/spec/services/spree_shopify_importer/data_savers/products/product_creator_spec.rb
+++ b/spec/services/spree_shopify_importer/data_savers/products/product_creator_spec.rb
@@ -5,20 +5,22 @@ describe SpreeShopifyImporter::DataSavers::Products::ProductCreator, type: :serv
 
   subject { described_class.new(product_data_feed) }
 
-  let(:delivery_profile_importer) { instance_double(SpreeShopifyImporter::Importers::DeliveryProfileImporter) }
-  before  do
-    authenticate_with_shopify
-    expect(SpreeShopifyImporter::Importers::DeliveryProfileImporter).to receive(:new).and_return(delivery_profile_importer)
-    expect(delivery_profile_importer).to receive(:call)
-  end
-  after   { ShopifyAPI::Base.clear_session }
+  before { authenticate_with_shopify }
+  after { ShopifyAPI::Base.clear_session }
 
   describe '#create!' do
     context 'with base product data feed', vcr: { cassette_name: 'shopify/base_product' } do
       let(:shopify_product) { ShopifyAPI::Product.find(11_101_525_828) }
       let(:product_data_feed) do
         create(:shopify_data_feed,
-               shopify_object_id: shopify_product.id, data_feed: shopify_product.to_json)
+               shopify_object_id: shopify_product.id,
+               data_feed: shopify_product.to_json)
+      end
+      let(:delivery_profile_importer) { instance_double(SpreeShopifyImporter::Importers::DeliveryProfileImporter) }
+
+      before do
+        expect(SpreeShopifyImporter::Importers::DeliveryProfileImporter).to receive(:new).and_return(delivery_profile_importer)
+        expect(delivery_profile_importer).to receive(:call)
       end
 
       it 'create spree product' do
@@ -27,6 +29,7 @@ describe SpreeShopifyImporter::DataSavers::Products::ProductCreator, type: :serv
 
       it 'assigns shopify data feed to product' do
         subject.create!
+
         expect(product_data_feed.reload.spree_object).to eq Spree::Product.find_by!(name: shopify_product.title)
       end
 
@@ -34,29 +37,14 @@ describe SpreeShopifyImporter::DataSavers::Products::ProductCreator, type: :serv
         let(:spree_product) { Spree::Product.find_by!(slug: shopify_product.handle) }
         let(:shipping_category) { Spree::ShippingCategory.find_by!(name: I18n.t(:shopify)) }
 
-        before { subject.create! }
+        it 'assigns correct product attributes' do
+          subject.create!
 
-        it 'description' do
           expect(spree_product.description).to eq shopify_product.body_html
-        end
-
-        it 'available_on' do
           expect(spree_product.available_on).to eq shopify_product.published_at
-        end
-
-        it 'slug' do
           expect(spree_product.slug).to eq shopify_product.handle
-        end
-
-        it 'created_at' do
           expect(spree_product.created_at).to eq shopify_product.created_at
-        end
-
-        it 'price' do
           expect(spree_product.price).to eq shopify_product.variants.first.price.to_d
-        end
-
-        it 'shipping_category' do
           expect(spree_product.shipping_category).to eq shipping_category
         end
       end
@@ -129,7 +117,7 @@ describe SpreeShopifyImporter::DataSavers::Products::ProductCreator, type: :serv
           end.to change(Spree::Image, :count).by(2)
         end
 
-        it 'assings variants to product' do
+        it 'assigns variants to product' do
           perform_enqueued_jobs do
             subject.create!
           end
@@ -203,11 +191,15 @@ describe SpreeShopifyImporter::DataSavers::Products::ProductCreator, type: :serv
           end
 
           context 'with case insensitive' do
-            let!(:option_type2) { create(:option_type, name: shopify_product.options.last.name) }
-            let!(:option_type2_values) do
+            let(:option_type2) { create(:option_type, name: shopify_product.options.last.name) }
+            let(:option_type2_values) do
               shopify_product.options.last.values.map do |value|
                 create(:option_value, option_type: option_type2, name: value)
               end
+            end
+
+            before do
+              option_type2_values
             end
 
             it 'creates option values' do

--- a/spec/services/spree_shopify_importer/data_savers/products/product_creator_spec.rb
+++ b/spec/services/spree_shopify_importer/data_savers/products/product_creator_spec.rb
@@ -161,7 +161,11 @@ describe SpreeShopifyImporter::DataSavers::Products::ProductCreator, type: :serv
         end
 
         context 'with case insensitive option values' do
-          let!(:option_type1) { create(:option_type, name: shopify_product.options.first.name) }
+          let(:option_type1) { create(:option_type, name: shopify_product.options.first.name) }
+
+          before do
+            option_type1
+          end
 
           it 'creates option types' do
             expect { subject.create! }.to change(Spree::OptionType, :count).by(1)

--- a/spec/services/spree_shopify_importer/data_savers/products/product_updater_spec.rb
+++ b/spec/services/spree_shopify_importer/data_savers/products/product_updater_spec.rb
@@ -193,11 +193,15 @@ describe SpreeShopifyImporter::DataSavers::Products::ProductUpdater, type: :serv
           end
 
           context 'with case insensitive' do
-            let!(:option_type2) { create(:option_type, name: shopify_product.options.last.name) }
-            let!(:option_type2_values) do
+            let(:option_type2) { create(:option_type, name: shopify_product.options.last.name) }
+            let(:option_type2_values) do
               shopify_product.options.last.values.map do |value|
                 create(:option_value, option_type: option_type2, name: value)
               end
+            end
+
+            before do
+              option_type2_values
             end
 
             it 'creates option values' do

--- a/spec/services/spree_shopify_importer/data_savers/products/product_updater_spec.rb
+++ b/spec/services/spree_shopify_importer/data_savers/products/product_updater_spec.rb
@@ -15,11 +15,15 @@ describe SpreeShopifyImporter::DataSavers::Products::ProductUpdater, type: :serv
 
   describe '#update!' do
     context 'with base product data feed', vcr: { cassette_name: 'shopify/base_product' } do
-      let!(:spree_product) { create(:product) }
+      let(:spree_product) { create(:product) }
       let(:shopify_product) { ShopifyAPI::Product.find(11_101_525_828) }
       let(:product_data_feed) do
         create(:shopify_data_feed,
                shopify_object_id: shopify_product.id, data_feed: shopify_product.to_json)
+      end
+
+      before do
+        spree_product
       end
 
       it 'does not create spree product' do
@@ -162,7 +166,11 @@ describe SpreeShopifyImporter::DataSavers::Products::ProductUpdater, type: :serv
         end
 
         context 'with case insensitive option values' do
-          let!(:option_type1) { create(:option_type, name: shopify_product.options.first.name) }
+          let(:option_type1) { create(:option_type, name: shopify_product.options.first.name) }
+
+          before do
+            option_type1
+          end
 
           it 'creates option types' do
             expect { subject.update! }.to change(Spree::OptionType, :count).by(1)

--- a/spec/services/spree_shopify_importer/data_savers/return_items/return_items_creator_spec.rb
+++ b/spec/services/spree_shopify_importer/data_savers/return_items/return_items_creator_spec.rb
@@ -1,19 +1,24 @@
 require 'spec_helper'
 
 describe SpreeShopifyImporter::DataSavers::ReturnItems::ReturnItemsCreator, type: :service do
+  subject { described_class.new(shopify_refund_line_item, shopify_refund, spree_return_authorization, spree_order) }
+
   let(:spree_return_authorization) { create(:return_authorization) }
   let(:spree_order) { create(:order_with_line_items) }
 
-  subject { described_class.new(shopify_refund_line_item, shopify_refund, spree_return_authorization, spree_order) }
   before  { authenticate_with_shopify }
   after   { ShopifyAPI::Base.clear_session }
 
   describe '#create' do
-    let!(:variant) do
+    let(:variant) do
       create(:shopify_data_feed,
              shopify_object_id: shopify_refund_line_item.line_item.variant_id,
              shopify_object_type: 'ShopifyAPI::Variant',
              spree_object: spree_order.line_items.first.variant)
+    end
+
+    before do
+      variant
     end
 
     context 'with base refund data', vcr: { cassette_name: 'shopify/base_refund' } do
@@ -23,12 +28,6 @@ describe SpreeShopifyImporter::DataSavers::ReturnItems::ReturnItemsCreator, type
 
       it 'creates return items' do
         expect { subject.create }.to change(Spree::ReturnItem, :count).by(1)
-      end
-
-      context 'with missing inventory units' do
-        it 'creates inventory units'
-        it 'creates dummy shipments'
-        it 'creates return items'
       end
     end
   end

--- a/spec/services/spree_shopify_importer/data_savers/shipping_methods/shipping_method_creator_spec.rb
+++ b/spec/services/spree_shopify_importer/data_savers/shipping_methods/shipping_method_creator_spec.rb
@@ -1,13 +1,17 @@
 require 'spec_helper'
 
 describe SpreeShopifyImporter::DataSavers::ShippingMethods::ShippingMethodCreator, type: :service do
+  subject { described_class.new(shopify_rate, delivery_profile_id) }
+
   let(:shopify_rate) { shopify_shipping_zone.weight_based_shipping_rates.first }
   let(:delivery_profile_id) { shopify_shipping_zone.profile_id.split('/').last }
-  let!(:shipping_category) { create(:shipping_category, name: 'GENERAL PROFILE/18869387313') }
-  let!(:calculator) { create(:shipping_calculator) }
-  before { authenticate_with_shopify }
+  let(:shipping_category) { create(:shipping_category, name: 'GENERAL PROFILE/18869387313') }
+  let(:calculator) { create(:shipping_calculator) }
 
-  subject { described_class.new(shopify_rate, delivery_profile_id) }
+  before do
+    shipping_category
+    authenticate_with_shopify
+  end
 
   describe '#call', vcr: { cassette_name: 'shopify/base_country_zone' } do
     let(:shopify_shipping_zone) { ShopifyAPI::ShippingZone.first }
@@ -19,13 +23,17 @@ describe SpreeShopifyImporter::DataSavers::ShippingMethods::ShippingMethodCreato
     end
 
     context 'with existed shipping method' do
-      let!(:shipping_method) do
+      let(:shipping_method) do
         create(:shipping_method,
                name: 'Standard Shipping',
                display_on: 'both',
                admin_name: 'GENERAL PROFILE',
                shipping_categories: [shipping_category],
                calculator: calculator)
+      end
+
+      before do
+        shipping_method
       end
 
       it 'does not create shipping category' do

--- a/spec/services/spree_shopify_importer/data_savers/shipping_rates/shipping_rate_creator_spec.rb
+++ b/spec/services/spree_shopify_importer/data_savers/shipping_rates/shipping_rate_creator_spec.rb
@@ -1,15 +1,20 @@
 require 'spec_helper'
 
 describe SpreeShopifyImporter::DataSavers::ShippingRates::ShippingRateCreator, type: :service do
-  let(:shopify_order)         { ShopifyAPI::Order.find(5_182_437_124) }
-  let(:shopify_shipping_line) { shopify_order.shipping_lines.first }
-  let!(:spree_shipment)       { create(:shipment) }
-
   subject { described_class.new(shopify_shipping_line, shopify_order, spree_shipment) }
-  before  { authenticate_with_shopify }
-  after   { ShopifyAPI::Base.clear_session }
+
+  let(:spree_shipment) { create(:shipment) }
+
+  before do
+    spree_shipment
+    authenticate_with_shopify
+  end
+  after { ShopifyAPI::Base.clear_session }
 
   describe '#save!', vcr: { cassette_name: 'shopify/base_order' } do
+    let(:shopify_order) { ShopifyAPI::Order.find(5_182_437_124) }
+    let(:shopify_shipping_line) { shopify_order.shipping_lines.first }
+
     let(:shipping_rate) { Spree::ShippingRate.last }
 
     it 'creates shipping rate' do

--- a/spec/services/spree_shopify_importer/data_savers/tax_rates/tax_rate_creator_spec.rb
+++ b/spec/services/spree_shopify_importer/data_savers/tax_rates/tax_rate_creator_spec.rb
@@ -1,21 +1,25 @@
 require 'spec_helper'
 
 describe SpreeShopifyImporter::DataSavers::TaxRates::TaxRateCreator, type: :service do
-  let(:shopify_object) { build_stubbed(:shopify_country) }
-  let(:spree_zone) { create(:zone, name: 'Domestic/Poland/GENERAL PROFILE') }
-  let!(:tax_category) { create(:tax_category, name: 'GENERAL PROFILE/18869387313') }
-  let(:calculator) { Spree::Calculator::ShopifyTax.last }
-  let!(:shop_data_feed) do
-    create(:shopify_data_feed,
-           shopify_object_type: 'ShopifyAPI::Shop',
-           data_feed: '{"taxes_included":true}')
-  end
-
   subject { described_class.new(spree_zone, shopify_object) }
 
-  before { authenticate_with_shopify }
+  let(:spree_zone) { create(:zone, name: 'Domestic/Poland/GENERAL PROFILE') }
+  let(:shopify_object) { build_stubbed(:shopify_country) }
 
   describe '#create!' do
+    let(:tax_category) { create(:tax_category, name: 'GENERAL PROFILE/18869387313') }
+    let(:calculator) { Spree::Calculator::ShopifyTax.last }
+    let(:shop_data_feed) do
+      create(:shopify_data_feed,
+             shopify_object_type: 'ShopifyAPI::Shop',
+             data_feed: '{"taxes_included":true}')
+    end
+
+    before do
+      shop_data_feed
+      tax_category
+    end
+
     it 'creates tax rate' do
       expect { subject.create! }.to change(Spree::TaxRate, :count).by(1)
     end

--- a/spec/services/spree_shopify_importer/data_savers/taxons/taxon_creator_spec.rb
+++ b/spec/services/spree_shopify_importer/data_savers/taxons/taxon_creator_spec.rb
@@ -25,38 +25,32 @@ describe SpreeShopifyImporter::DataSavers::Taxons::TaxonCreator, type: :service 
     end
 
     context 'taxon attributes' do
+      it 'assigns correct taxon attributes' do
+        subject.create!
 
-      before { subject.create! }
-
-      it 'name' do
         expect(spree_taxon.name).to eq shopify_custom_collection.title
-      end
-
-      it 'permalink' do
-
         expect(spree_taxon.permalink).to eq "shopify-custom-collections/#{shopify_custom_collection.handle}"
-      end
-
-      it 'description' do
         expect(spree_taxon.description).to eq shopify_custom_collection.body_html
       end
     end
 
     context 'associations' do
-      context 'products' do
-        let!(:spree_product) { create(:product) }
-        let!(:product_data_feed) do
-          create(:shopify_data_feed,
-                 shopify_object_type: 'ShopifyAPI::Product',
-                 shopify_object_id: '11055169028',
-                 spree_object: spree_product)
-        end
+      let(:spree_product) { create(:product) }
+      let(:product_data_feed) do
+        create(:shopify_data_feed,
+               shopify_object_type: 'ShopifyAPI::Product',
+               shopify_object_id: '11055169028',
+               spree_object: spree_product)
+      end
 
-        before { subject.create! }
+      before do
+        product_data_feed
+      end
 
-        it 'assigns products to spree_taxon' do
-          expect(spree_taxon.products).to contain_exactly(spree_product)
-        end
+      it 'assigns products to spree_taxon' do
+        subject.create!
+
+        expect(spree_taxon.products).to contain_exactly(spree_product)
       end
     end
   end

--- a/spec/services/spree_shopify_importer/data_savers/taxons/taxon_updater_spec.rb
+++ b/spec/services/spree_shopify_importer/data_savers/taxons/taxon_updater_spec.rb
@@ -34,17 +34,21 @@ describe SpreeShopifyImporter::DataSavers::Taxons::TaxonUpdater, type: :service 
 
     context 'associations' do
       context 'products' do
-        let!(:spree_product) { create(:product) }
-        let!(:product_data_feed) do
+        let(:spree_product) { create(:product) }
+        let(:product_data_feed) do
           create(:shopify_data_feed,
                  shopify_object_type: 'ShopifyAPI::Product',
                  shopify_object_id: '11055169028',
                  spree_object: spree_product)
         end
 
-        before { subject.update! }
+        before do
+          product_data_feed
+        end
 
         it 'assigns products to spree_taxon' do
+          subject.update!
+
           expect(spree_taxon.products).to contain_exactly(spree_product)
         end
       end

--- a/spec/services/spree_shopify_importer/data_savers/taxons/taxon_updater_spec.rb
+++ b/spec/services/spree_shopify_importer/data_savers/taxons/taxon_updater_spec.rb
@@ -10,7 +10,11 @@ describe SpreeShopifyImporter::DataSavers::Taxons::TaxonUpdater, type: :service 
     let(:shopify_data_feed) { create(:shopify_data_feed, data_feed: shopify_custom_collection.to_json) }
     let(:taxonomy) { create(:taxonomy, name: I18n.t('shopify_custom_collections')) }
 
-    let!(:spree_taxon) { create(:taxon, taxonomy: taxonomy, parent: taxonomy.root) }
+    let(:spree_taxon) { create(:taxon, taxonomy: taxonomy, parent: taxonomy.root) }
+
+    before do
+      spree_taxon
+    end
 
     it 'does not create spree taxon' do
       expect { subject.update! }.not_to change { Spree::Taxon.where.not(parent: nil).reload.count }

--- a/spec/services/spree_shopify_importer/data_savers/users/user_updater_spec.rb
+++ b/spec/services/spree_shopify_importer/data_savers/users/user_updater_spec.rb
@@ -5,54 +5,30 @@ describe SpreeShopifyImporter::DataSavers::Users::UserUpdater, type: :service do
 
   subject { described_class.new(customer_data_feed, spree_user) }
 
-  before { ShopifyAPI::Base.site = 'https://foo:baz@test_shop.myshopify.com/admin' }
+  let(:customer_data_feed) { create(:shopify_data_feed, data_feed: shopify_customer.to_json) }
+  let(:shopify_customer) do
+    ShopifyAPI::Customer.new(
+      created_at: 2.days.ago, email: 'user@example.com',
+      first_name: 'User', last_name: 'Example'
+    )
+  end
+  let(:spree_user) { create(:user) }
 
   describe '#create!' do
     context 'with base customer data feed' do
-      let!(:spree_user) { create(:user) }
-      let(:shopify_customer) do
-        ShopifyAPI::Customer.new(
-          created_at: 2.days.ago, email: 'user@example.com',
-          first_name: 'User', last_name: 'Example'
-        )
-      end
-      let(:customer_data_feed) { create(:shopify_data_feed, data_feed: shopify_customer.to_json) }
-
-      it 'create spree user' do
-        expect { subject.update! }.not_to change(Spree.user_class, :count)
-      end
-
-      it 'generates spree api key' do
+      it 'generates correct attributes and associations' do
         subject.update!
 
         expect(spree_user.spree_api_key).not_to be_blank
-      end
-
-      context 'customer attributes' do
-        it 'email' do
-          subject.update!
-
-          expect(spree_user.email).to eq(shopify_customer.email)
-        end
-
-        it 'assigns login from email' do
-          subject.update!
-
-          expect(spree_user.login).to eq(shopify_customer.email)
-        end
-
-        it 'created_at' do
-          subject.update!
-
-          expect(spree_user.created_at).to be_within(1.second).of(shopify_customer.created_at)
-        end
+        expect(spree_user.email).to eq(shopify_customer.email)
+        expect(spree_user.login).to eq(shopify_customer.email)
       end
 
       context 'customer associations' do
-        let(:shopify_address) { create(:shopify_address) }
+        let(:shopify_address) { build_stubbed(:shopify_address) }
 
         before do
-          allow_any_instance_of(ShopifyAPI::Customer).to receive(:addresses).and_return([shopify_address])
+          expect_any_instance_of(ShopifyAPI::Customer).to receive(:addresses).and_return([shopify_address])
         end
 
         it 'creates spree address' do

--- a/spec/services/spree_shopify_importer/data_savers/variants/variant_updater_spec.rb
+++ b/spec/services/spree_shopify_importer/data_savers/variants/variant_updater_spec.rb
@@ -3,34 +3,36 @@ require 'spec_helper'
 RSpec.describe SpreeShopifyImporter::DataSavers::Variants::VariantUpdater, type: :service do
   include ActiveJob::TestHelper
 
-  let!(:spree_product) { create(:product) }
-  let!(:spree_variant) { create(:variant, product: spree_product) }
-  let(:shopify_variant) { create(:shopify_variant, sku: '1234') }
-  let(:option_type) { create(:option_type) }
+  subject { described_class.new(shopify_data_feed, spree_variant, spree_product) }
+
   let(:shopify_data_feed) do
     create(:shopify_data_feed,
            shopify_object_type: 'ShopifyAPI::Variant',
            shopify_object_id: shopify_variant.id,
            data_feed: shopify_variant.to_json)
   end
-  let!(:f_option_value) do
-    create(:option_value, name: shopify_variant.option1.strip.downcase, option_type: option_type)
-  end
-  let!(:s_option_value) do
-    create(:option_value, name: shopify_variant.option2.strip.downcase, option_type: option_type)
-  end
-  let!(:t_option_value) do
-    create(:option_value, name: shopify_variant.option3.strip.downcase, option_type: option_type)
-  end
-
-  subject { described_class.new(shopify_data_feed, spree_variant, spree_product) }
-
-  before do
-    spree_product.option_types << option_type
-  end
+  let(:spree_variant) { create(:variant, product: spree_product) }
+  let(:spree_product) { create(:product) }
 
   describe '#update!' do
+    let(:shopify_variant) { create(:shopify_variant, sku: '1234', inventory_management: inventory_management) }
+    let(:inventory_management) { 'shopify' }
+
+    let(:option_type) { create(:option_type) }
+
+    let(:f_option_value) { create(:option_value, name: shopify_variant.option1.strip.downcase, option_type: option_type) }
+    let(:s_option_value) { create(:option_value, name: shopify_variant.option2.strip.downcase, option_type: option_type) }
+    let(:t_option_value) { create(:option_value, name: shopify_variant.option3.strip.downcase, option_type: option_type) }
+
+    before do
+      f_option_value
+      s_option_value
+      t_option_value
+      spree_product.option_types << option_type
+    end
+
     it 'does not create spree variant' do
+      spree_variant
       expect { subject.update! }.not_to change(Spree::Variant, :count)
     end
 
@@ -41,37 +43,31 @@ RSpec.describe SpreeShopifyImporter::DataSavers::Variants::VariantUpdater, type:
     end
 
     context 'base variant attributes' do
-      before { subject.update! }
+      it 'saves attributes' do
+        subject.update!
 
-      it 'saves variant sku' do
         expect(spree_variant.sku).to eq shopify_variant.sku
-      end
-
-      it 'saves variant price' do
         expect(spree_variant.price).to eq shopify_variant.price
-      end
-
-      it 'saves variant weight' do
         expect(spree_variant.weight).to eq shopify_variant.grams
       end
     end
 
     context 'variant stock' do
       context 'track inventory' do
-        before { subject.update! }
-
         context 'resource in shopify was tracking inventory' do
-          let(:shopify_variant) { create(:shopify_variant, inventory_management: 'shopify') }
-
           it 'then it is tracking inventory' do
+            subject.update!
+
             expect(spree_variant).to be_track_inventory
           end
         end
 
         context 'resource in shopify was not tracking inventory' do
-          let(:shopify_variant) { create(:shopify_variant, inventory_management: 'not_shopify') }
+          let(:inventory_management) { 'not_shopify'  }
 
           it 'then it is not tracking inventory' do
+            subject.update!
+
             expect(spree_variant).not_to be_track_inventory
           end
         end

--- a/spec/services/spree_shopify_importer/data_savers/zones/zone_updater_spec.rb
+++ b/spec/services/spree_shopify_importer/data_savers/zones/zone_updater_spec.rb
@@ -10,21 +10,21 @@ describe SpreeShopifyImporter::DataSavers::Zones::ZoneUpdater, type: :service do
   describe '#update!' do
     context 'with country shipping_zone data feed', vcr: { cassette_name: 'shopify/base_country_zone' } do
       let(:shopify_shipping_zone) { ShopifyAPI::ShippingZone.first }
-      let!(:shipping_zone_data_feed) do
+      let(:shipping_zone_data_feed) do
         create(:shopify_data_feed,
                shopify_object_id: shopify_shipping_zone.id,
                shopify_object_type: shopify_shipping_zone.class.name,
                data_feed: shopify_shipping_zone.to_json)
       end
-      let!(:old_zone_data_feed) do
+      let(:old_zone_data_feed) do
         create(:shopify_data_feed,
                shopify_object_id: 516_252_868,
                shopify_object_type: 'ShopifyAPI::Country',
                parent_id: shipping_zone_data_feed.id)
       end
-      let!(:country) { create(:country, iso: 'HR') }
-      let!(:spree_zone) { create(:zone, name: 'Domestic/Croatia/GENERAL PROFILE', kind: 'country') }
-      let!(:old_spree_zone_member) { create(:zone_member, zoneable: country, zone: spree_zone) }
+      let(:country) { create(:country, iso: 'HR') }
+      let(:spree_zone) { create(:zone, name: 'Domestic/Croatia/GENERAL PROFILE', kind: 'country') }
+      let(:old_spree_zone_member) { create(:zone_member, zoneable: country, zone: spree_zone) }
       let(:parent_object) { shopify_shipping_zone }
       let(:shopify_object) { parent_object.countries.first }
       let(:new_spree_zone_member) do
@@ -35,13 +35,22 @@ describe SpreeShopifyImporter::DataSavers::Zones::ZoneUpdater, type: :service do
         )
       end
 
-      let!(:tax_category) { create(:tax_category, name: 'GENERAL PROFILE/18869387313') }
-      let!(:shop_data_feed) do
+      let(:tax_category) { create(:tax_category, name: 'GENERAL PROFILE/18869387313') }
+      let(:shop_data_feed) do
         create(:shopify_data_feed,
                shopify_object_type: 'ShopifyAPI::Shop',
                data_feed: '{"taxes_included":true}')
       end
       let(:shipping_methods) { [create(:shipping_method, zones: [])] }
+
+      before do
+        shop_data_feed
+        tax_category
+        old_spree_zone_member
+        spree_zone
+        country
+        old_zone_data_feed
+      end
 
       it 'does not create spree zone' do
         expect { subject.update! }.not_to change(Spree::Zone, :count)

--- a/spec/services/spree_shopify_importer/delegator_spec.rb
+++ b/spec/services/spree_shopify_importer/delegator_spec.rb
@@ -2,7 +2,8 @@ require 'spec_helper'
 
 describe SpreeShopifyImporter::Delegator, type: :service do
   subject { described_class.new(target) }
-  let!(:target) { spy('Object') }
+
+  let(:target) { spy('Object') }
   let(:helper) { SpreeShopifyImporter::RescueApiLimit }
 
   describe '#method_missing' do

--- a/spec/services/spree_shopify_importer/importers/address_importer_spec.rb
+++ b/spec/services/spree_shopify_importer/importers/address_importer_spec.rb
@@ -19,11 +19,18 @@ describe SpreeShopifyImporter::Importers::AddressImporter, type: :service do
     end
 
     context 'with existing data feed' do
-      let!(:shopify_data_feed) do
+      let(:shopify_data_feed) do
         create(:shopify_data_feed,
                shopify_object_id: shopify_address.id,
                shopify_object_type: 'ShopifyAPI::Address',
-               data_feed: resource, spree_object: nil)
+               data_feed: resource,
+               spree_object: spree_object)
+      end
+
+      let(:spree_object) { nil }
+
+      before do
+        shopify_data_feed
       end
 
       it 'does not create shopify data feeds' do
@@ -35,13 +42,7 @@ describe SpreeShopifyImporter::Importers::AddressImporter, type: :service do
       end
 
       context 'and address' do
-        let!(:shopify_data_feed) do
-          create(:shopify_data_feed,
-                 shopify_object_id: shopify_address.id,
-                 shopify_object_type: 'ShopifyAPI::Address',
-                 data_feed: resource,
-                 spree_object: create(:address))
-        end
+        let(:spree_object) { create(:address) }
 
         it 'does not create shopify data feeds' do
           expect { subject.import! }.not_to change(SpreeShopifyImporter::DataFeed, :count)

--- a/spec/services/spree_shopify_importer/importers/image_importer_spec.rb
+++ b/spec/services/spree_shopify_importer/importers/image_importer_spec.rb
@@ -1,18 +1,19 @@
 require 'spec_helper'
 
 describe SpreeShopifyImporter::Importers::ImageImporter, type: :service do
-  let(:valid_src) do
-    'https://cdn.shopify.com/s/files/1/2051/3691/'\
-    'products/Screenshot_2017-03-03_14.45.16_29b97e8b-f008-460f-8733-b33d551d7140.png?v=1496631699'
-  end
-  let!(:shopify_image) { create(:shopify_image, sku: 'random-sku', src: valid_src) }
-  let!(:resource) { shopify_image.to_json }
-  let!(:parent_feed) { create(:shopify_data_feed) }
-  let!(:spree_product) { create(:product) }
-
   subject { described_class.new(resource, parent_feed, spree_product) }
 
+  let(:resource) { shopify_image.to_json }
+  let(:parent_feed) { create(:shopify_data_feed) }
+  let(:spree_product) { create(:product) }
+  let(:shopify_image) { create(:shopify_image, sku: 'random-sku', src: valid_src) }
+  let(:valid_src) { 'https://cdn.shopify.com/s/files/1/2051/3691/products/Screenshot_2017-03-03_14.45.16_29b97e8b-f008-460f-8733-b33d551d7140.png?v=1496631699' }
+
   describe '#import!', vcr: { cassette_name: 'shopify_import/importers/image_importer' } do
+    before do
+      parent_feed
+    end
+
     it 'creates shopify data feeds' do
       expect { subject.import! }.to change(SpreeShopifyImporter::DataFeed, :count).by(1)
     end
@@ -22,11 +23,17 @@ describe SpreeShopifyImporter::Importers::ImageImporter, type: :service do
     end
 
     context 'with existing data feed' do
-      let!(:shopify_data_feed) do
+      let(:shopify_data_feed) do
         create(:shopify_data_feed,
                shopify_object_id: shopify_image.id,
                shopify_object_type: shopify_image.class.to_s,
-               data_feed: resource, spree_object: nil)
+               data_feed: resource,
+               spree_object: spree_object)
+      end
+      let(:spree_object) { nil }
+
+      before do
+        shopify_data_feed
       end
 
       it 'does not create shopify data feeds' do
@@ -38,12 +45,7 @@ describe SpreeShopifyImporter::Importers::ImageImporter, type: :service do
       end
 
       context 'and image' do
-        let!(:shopify_data_feed) do
-          create(:shopify_data_feed,
-                 shopify_object_id: shopify_image.id,
-                 shopify_object_type: 'ShopifyAPI::Image',
-                 data_feed: resource, spree_object: create(:image))
-        end
+        let(:spree_object) { create(:image) }
 
         it 'does not create shopify data feeds' do
           expect { subject.import! }.not_to change(SpreeShopifyImporter::DataFeed, :count)

--- a/spec/services/spree_shopify_importer/importers/order_importer_spec.rb
+++ b/spec/services/spree_shopify_importer/importers/order_importer_spec.rb
@@ -2,21 +2,23 @@ require 'spec_helper'
 
 describe SpreeShopifyImporter::Importers::OrderImporter, type: :service do
   subject { described_class.new(resource) }
+
   before  { authenticate_with_shopify }
   after   { ShopifyAPI::Base.clear_session }
 
   describe '#import!', vcr: { cassette_name: 'shopify_import/importers/order_importer' } do
-    let!(:shopify_order) { ShopifyAPI::Order.find(5_182_437_124) }
-    let!(:user) { create(:user) }
-    let!(:user_data_feed) do
+    let(:resource) { shopify_order.to_json }
+    let(:shopify_order) { ShopifyAPI::Order.find(5_182_437_124) }
+    let(:user) { create(:user) }
+    let(:user_data_feed) do
       create(:shopify_data_feed,
              spree_object: user,
              shopify_object_id: shopify_order.customer.id,
              shopify_object_type: 'ShopifyAPI::Customer')
     end
-    let(:resource) { shopify_order.to_json }
 
     before do
+      user_data_feed
       shopify_order.line_items.each do |line_item|
         create(:shopify_data_feed,
                spree_object: create(:variant),

--- a/spec/services/spree_shopify_importer/importers/payment_importer_spec.rb
+++ b/spec/services/spree_shopify_importer/importers/payment_importer_spec.rb
@@ -1,16 +1,21 @@
 require 'spec_helper'
 
 describe SpreeShopifyImporter::Importers::PaymentImporter, type: :service do
-  let(:transaction)  { shopify_order.transactions.first }
-  let!(:parent_feed) { create(:shopify_data_feed) }
-  let!(:spree_order) { create(:order) }
-
   subject { described_class.new(transaction, parent_feed, spree_order) }
+
+  let(:transaction) { shopify_order.transactions.first }
+  let(:parent_feed) { create(:shopify_data_feed) }
+  let(:spree_order) { create(:order) }
+
   before  { authenticate_with_shopify }
   after   { ShopifyAPI::Base.clear_session }
 
   describe '#import!', vcr: { cassette_name: 'shopify/base_order' } do
     let(:shopify_order) { ShopifyAPI::Order.find(5_182_437_124) }
+
+    before do
+      parent_feed
+    end
 
     it 'creates shopify data feeds' do
       expect { subject.import! }.to change(SpreeShopifyImporter::DataFeed, :count).by(1)
@@ -21,11 +26,15 @@ describe SpreeShopifyImporter::Importers::PaymentImporter, type: :service do
     end
 
     context 'with existing data feed' do
-      let!(:shopify_data_feed) do
+      let(:shopify_data_feed) do
         create(:shopify_data_feed,
                shopify_object_id: transaction.id,
                shopify_object_type: 'ShopifyAPI::Transaction',
                data_feed: transaction.to_json)
+      end
+
+      before do
+        shopify_data_feed
       end
 
       it 'creates shopify data feeds' do

--- a/spec/services/spree_shopify_importer/importers/product_importer_spec.rb
+++ b/spec/services/spree_shopify_importer/importers/product_importer_spec.rb
@@ -4,6 +4,7 @@ describe SpreeShopifyImporter::Importers::ProductImporter, type: :service do
   include ActiveJob::TestHelper
 
   subject { described_class.new(resource) }
+
   before  { authenticate_with_shopify }
   after   { ShopifyAPI::Base.clear_session }
 
@@ -36,11 +37,17 @@ describe SpreeShopifyImporter::Importers::ProductImporter, type: :service do
 
     context 'with existing' do
       context 'data feed' do
-        let!(:data_feed) do
+        let(:data_feed) do
           create(:shopify_data_feed,
                  shopify_object_id: 11_101_525_828,
                  shopify_object_type: 'ShopifyAPI::Product',
-                 data_feed: resource.to_json, spree_object: nil)
+                 data_feed: resource.to_json,
+                 spree_object: spree_object)
+        end
+        let(:spree_object) { nil }
+
+        before do
+          data_feed
         end
 
         it 'creates shopify data feeds' do
@@ -68,13 +75,7 @@ describe SpreeShopifyImporter::Importers::ProductImporter, type: :service do
         end
 
         context 'and product' do
-          let!(:data_feed) do
-            create(:shopify_data_feed,
-                   shopify_object_id: 11_101_525_828,
-                   shopify_object_type: 'ShopifyAPI::Product',
-                   data_feed: resource.to_json,
-                   spree_object: create(:product))
-          end
+          let(:spree_object) { create(:product) }
 
           it 'creates only variant shopify data feeds' do
             expect do

--- a/spec/services/spree_shopify_importer/importers/return_authorization_importer_spec.rb
+++ b/spec/services/spree_shopify_importer/importers/return_authorization_importer_spec.rb
@@ -1,11 +1,16 @@
 require 'spec_helper'
 
 describe SpreeShopifyImporter::Importers::ReturnAuthorizationImporter, type: :service do
-  let!(:parent_feed) { create(:shopify_data_feed) }
-  let!(:spree_order) { create(:order) }
   subject { described_class.new(shopify_refund, parent_feed, spree_order) }
-  before  { authenticate_with_shopify }
-  after   { ShopifyAPI::Base.clear_session }
+
+  let(:parent_feed) { create(:shopify_data_feed) }
+  let(:spree_order) { create(:order) }
+
+  before do
+    parent_feed
+    authenticate_with_shopify
+  end
+  after { ShopifyAPI::Base.clear_session }
 
   describe '#import!' do
     context 'with basic return authorization data', vcr: { cassette_name: 'shopify/order_with_refund' } do
@@ -20,11 +25,15 @@ describe SpreeShopifyImporter::Importers::ReturnAuthorizationImporter, type: :se
       end
 
       context 'with existing data feed' do
-        let!(:shopify_data_feed) do
+        let(:shopify_data_feed) do
           create(:shopify_data_feed,
                  shopify_object_id: shopify_refund.id,
                  shopify_object_type: 'ShopifyAPI::Refund',
                  data_feed: shopify_refund.to_json)
+        end
+
+        before do
+          shopify_data_feed
         end
 
         it 'does not create shopify data feeds' do

--- a/spec/services/spree_shopify_importer/importers/shop_importer_spec.rb
+++ b/spec/services/spree_shopify_importer/importers/shop_importer_spec.rb
@@ -1,9 +1,9 @@
 require 'spec_helper'
 
 describe SpreeShopifyImporter::Importers::ShopImporter, type: :service do
-  let(:resource) { '{"id":20513691,"name":"Spree Shopify Importer Test Store" }' }
-
   subject { described_class.new(resource) }
+
+  let(:resource) { '{"id":20513691,"name":"Spree Shopify Importer Test Store" }' }
 
   describe '#import!' do
     context 'without existing data feed' do
@@ -13,11 +13,15 @@ describe SpreeShopifyImporter::Importers::ShopImporter, type: :service do
     end
 
     context 'with existing data feed' do
-      let!(:shopify_data_feed) do
+      let(:shopify_data_feed) do
         create(:shopify_data_feed,
                shopify_object_id: 205_136_91,
                shopify_object_type: 'ShopifyAPI::Shop',
                data_feed: resource, spree_object: nil)
+      end
+
+      before do
+        shopify_data_feed
       end
 
       it 'does not create shopify data feeds' do

--- a/spec/services/spree_shopify_importer/importers/taxon_importer_spec.rb
+++ b/spec/services/spree_shopify_importer/importers/taxon_importer_spec.rb
@@ -2,6 +2,7 @@ require 'spec_helper'
 
 describe SpreeShopifyImporter::Importers::TaxonImporter, type: :service do
   subject { described_class.new(resource) }
+
   before  { authenticate_with_shopify }
   after   { ShopifyAPI::Base.clear_session }
 
@@ -23,11 +24,17 @@ describe SpreeShopifyImporter::Importers::TaxonImporter, type: :service do
     end
 
     context 'with existing data feed' do
-      let!(:shopify_data_feed) do
+      let(:shopify_data_feed) do
         create(:shopify_data_feed,
                shopify_object_id: shopify_custom_collection.id,
                shopify_object_type: 'ShopifyAPI::CustomCollection',
-               data_feed: resource, spree_object: nil)
+               data_feed: resource,
+               spree_object: spree_object)
+      end
+      let(:spree_object) { nil }
+
+      before do
+        shopify_data_feed
       end
 
       it 'does not create shopify data feeds' do
@@ -44,12 +51,7 @@ describe SpreeShopifyImporter::Importers::TaxonImporter, type: :service do
       end
 
       context 'and taxon' do
-        let!(:shopify_data_feed) do
-          create(:shopify_data_feed,
-                 shopify_object_id: shopify_custom_collection.id,
-                 shopify_object_type: 'ShopifyAPI::CustomCollection',
-                 data_feed: resource, spree_object: spree_taxon)
-        end
+        let(:spree_object) { spree_taxon }
         let(:spree_taxon) { create(:taxon, taxonomy: spree_taxonomy, parent: spree_taxonomy.root) }
         let(:spree_taxonomy) { create(:taxonomy, name: I18n.t('shopify_custom_collections')) }
 

--- a/spec/services/spree_shopify_importer/importers/user_importer_spec.rb
+++ b/spec/services/spree_shopify_importer/importers/user_importer_spec.rb
@@ -2,6 +2,7 @@ require 'spec_helper'
 
 describe SpreeShopifyImporter::Importers::UserImporter, type: :service do
   subject { described_class.new(resource) }
+
   before  { authenticate_with_shopify }
   after   { ShopifyAPI::Base.clear_session }
 
@@ -18,11 +19,17 @@ describe SpreeShopifyImporter::Importers::UserImporter, type: :service do
     end
 
     context 'with existing data feed' do
-      let!(:shopify_data_feed) do
+      let(:shopify_data_feed) do
         create(:shopify_data_feed,
                shopify_object_id: shopify_customer.id,
                shopify_object_type: 'ShopifyAPI::Customer',
-               data_feed: resource, spree_object: nil)
+               data_feed: resource,
+               spree_object: spree_object)
+      end
+      let(:spree_object) { nil }
+
+      before do
+        shopify_data_feed
       end
 
       it 'creates shopify data feeds' do
@@ -34,12 +41,7 @@ describe SpreeShopifyImporter::Importers::UserImporter, type: :service do
       end
 
       context 'and user' do
-        let!(:shopify_data_feed) do
-          create(:shopify_data_feed,
-                 shopify_object_id: shopify_customer.id,
-                 shopify_object_type: 'ShopifyAPI::Customer',
-                 data_feed: resource, spree_object: create(:user))
-        end
+        let(:spree_object) { create(:user) }
 
         it 'creates shopify data feeds' do
           expect { subject.import! }.not_to change(SpreeShopifyImporter::DataFeed, :count)

--- a/spec/vcr/shopify_import/data_parsers/line_item/missing_variant.yml
+++ b/spec/vcr/shopify_import/data_parsers/line_item/missing_variant.yml
@@ -210,4 +210,107 @@ http_interactions:
         Title"]}],"images":[{"id":26172377540,"product_id":11055169028,"position":1,"created_at":"2017-05-31T06:19:10+02:00","updated_at":"2017-05-31T06:19:10+02:00","alt":null,"width":3584,"height":2270,"src":"https:\/\/cdn.shopify.com\/s\/files\/1\/2051\/3691\/products\/Screenshot_2017-02-21_14.44.34.png?v=1496204350","variant_ids":[],"admin_graphql_api_id":"gid:\/\/shopify\/ProductImage\/26172377540"}],"image":{"id":26172377540,"product_id":11055169028,"position":1,"created_at":"2017-05-31T06:19:10+02:00","updated_at":"2017-05-31T06:19:10+02:00","alt":null,"width":3584,"height":2270,"src":"https:\/\/cdn.shopify.com\/s\/files\/1\/2051\/3691\/products\/Screenshot_2017-02-21_14.44.34.png?v=1496204350","variant_ids":[],"admin_graphql_api_id":"gid:\/\/shopify\/ProductImage\/26172377540"}}}'
     http_version: 
   recorded_at: Thu, 19 Mar 2020 10:43:14 GMT
+- request:
+    method: get
+    uri: https://spree-products-importer.myshopify.com/admin/api/2019-10/products/11055169028.json
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Basic YzgyNzNiNzRhYjk2ZDdjNmFhMjU4Mzk3M2NiYjIxODk6MDBjYWJjNzdjYWM2MDllNjM4MDRkNDA2Yjc1YjlmMWU=
+      Accept:
+      - application/json
+      User-Agent:
+      - ShopifyAPI/8.1.0 ActiveResource/5.1.0 Ruby/2.6.3
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Date:
+      - Sun, 05 Apr 2020 21:24:47 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Set-Cookie:
+      - __cfduid=db2057e42e19ea83d2d5c129038bf87ad1586121887; expires=Tue, 05-May-20
+        21:24:47 GMT; path=/; domain=.myshopify.com; HttpOnly; SameSite=Lax
+      X-Sorting-Hat-Podid:
+      - '98'
+      X-Sorting-Hat-Shopid:
+      - '27653472355'
+      Vary:
+      - Accept-Encoding
+      Referrer-Policy:
+      - origin-when-cross-origin
+      X-Frame-Options:
+      - DENY
+      X-Shopid:
+      - '27653472355'
+      X-Shardid:
+      - '98'
+      X-Stats-Userid:
+      - ''
+      X-Stats-Apiclientid:
+      - '3154223'
+      X-Stats-Apipermissionid:
+      - '194747596899'
+      X-Shopify-Api-Terms:
+      - By accessing or using the Shopify API you agree to the Shopify API License
+        and Terms of Use at https://www.shopify.com/legal/api-terms
+      Http-X-Shopify-Shop-Api-Call-Limit:
+      - 1/40
+      X-Shopify-Shop-Api-Call-Limit:
+      - 1/40
+      X-Shopify-Api-Version:
+      - 2019-10
+      Strict-Transport-Security:
+      - max-age=7889238
+      X-Shopify-Stage:
+      - production
+      Content-Security-Policy:
+      - 'default-src ''self'' data: blob: ''unsafe-inline'' ''unsafe-eval'' https://*
+        shopify-pos://*; block-all-mixed-content; child-src ''self'' https://* shopify-pos://*;
+        connect-src ''self'' wss://* https://*; frame-ancestors ''none''; img-src
+        ''self'' data: blob: https:; script-src https://cdn.shopify.com https://cdn.shopify.cn
+        https://checkout.shopifycs.com https://js-agent.newrelic.com https://bam.nr-data.net
+        https://api.stripe.com https://mpsnare.iesnare.com https://appcenter.intuit.com
+        https://www.paypal.com https://js.braintreegateway.com https://c.paypal.com
+        https://maps.googleapis.com https://www.google-analytics.com https://v.shopify.com
+        https://widget.intercom.io https://js.intercomcdn.com ''self'' ''unsafe-inline''
+        ''unsafe-eval''; upgrade-insecure-requests; report-uri /csp-report?source%5Baction%5D=show&source%5Bapp%5D=Shopify&source%5Bcontroller%5D=admin%2Fproducts&source%5Bsection%5D=admin_api&source%5Buuid%5D=bc575eb8-36d5-4c4a-9de5-5462bda6df10'
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Xss-Protection:
+      - 1; mode=block; report=/xss-report?source%5Baction%5D=show&source%5Bapp%5D=Shopify&source%5Bcontroller%5D=admin%2Fproducts&source%5Bsection%5D=admin_api&source%5Buuid%5D=bc575eb8-36d5-4c4a-9de5-5462bda6df10
+      X-Dc:
+      - gcp-us-east1,gcp-us-central1,gcp-us-central1
+      X-Request-Id:
+      - bc575eb8-36d5-4c4a-9de5-5462bda6df10
+      Cf-Cache-Status:
+      - DYNAMIC
+      Expect-Ct:
+      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 57f656831ffff2b8-WAW
+      Alt-Svc:
+      - h3-27=":443"; ma=86400, h3-25=":443"; ma=86400, h3-24=":443"; ma=86400, h3-23=":443";
+        ma=86400
+    body:
+      encoding: ASCII-8BIT
+      string: '{"errors":"Not Found"}'
+    http_version: 
+  recorded_at: Sun, 05 Apr 2020 21:24:47 GMT
 recorded_with: VCR 5.0.0

--- a/spree_shopify_importer.gemspec
+++ b/spree_shopify_importer.gemspec
@@ -17,8 +17,6 @@ Gem::Specification.new do |s|
   s.homepage  = 'https://github.com/spark-solutions/spree_shopify_importer'
   s.license   = 'BSD-3-Clause'
 
-  # s.files       = `git ls-files`.split("\n")
-  # s.test_files  = `git ls-files -- {test,spec,features}/*`.split("\n")
   s.require_path = 'lib'
   s.requirements << 'none'
 
@@ -33,23 +31,15 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'capybara'
   s.add_development_dependency 'capybara-screenshot'
   s.add_development_dependency 'codeclimate-test-reporter'
-  s.add_development_dependency 'coffee-rails'
   s.add_development_dependency 'database_cleaner'
   s.add_development_dependency 'factory_bot', '~> 4.7'
   s.add_development_dependency 'ffaker'
-  s.add_development_dependency 'guard'
-  s.add_development_dependency 'guard-bundler'
-  s.add_development_dependency 'guard-rspec'
-  s.add_development_dependency 'guard-rubocop'
   s.add_development_dependency 'rubocop-rails'
-  s.add_development_dependency 'guard-spring'
   s.add_development_dependency 'mysql2'
   s.add_development_dependency 'pg'
   s.add_development_dependency 'pry-rails'
-  s.add_development_dependency 'rspec-rails', '~> 4.0.0.beta2'
+  s.add_development_dependency 'rspec-rails', '~> 4.0.0'
   s.add_development_dependency 'rubocop-rspec'
-  s.add_development_dependency 'sass-rails'
-  s.add_development_dependency 'selenium-webdriver'
   s.add_development_dependency 'shoulda-matchers'
   s.add_development_dependency 'simplecov'
   s.add_development_dependency 'spring-commands-rspec'


### PR DESCRIPTION
- Impoving tests speed by changing `create` to `build_stubbed` where possible
- Get rid of `let!` to be more explicit (make tests more easy to read)
- Remove some unnecessary dependencies for gem